### PR TITLE
RD-1222 Disable ESLint rules that are covered by TypeScript

### DIFF
--- a/configs/eslint-ts-overrides.json
+++ b/configs/eslint-ts-overrides.json
@@ -53,6 +53,7 @@
                 "jsdoc/require-param-type": "off",
                 "@typescript-eslint/no-unused-vars": "off",
                 "@typescript-eslint/no-use-before-define": "off",
+                "react/jsx-no-undef": "off",
 
                 /**
                  * NOTE: Default props for functional components are to be deprecated (https://github.com/reactjs/rfcs/pull/107)

--- a/configs/eslint-ts-overrides.json
+++ b/configs/eslint-ts-overrides.json
@@ -51,7 +51,14 @@
                 // NOTE: covered by TypeScript
                 "jsdoc/require-returns-type": "off",
                 "jsdoc/require-param-type": "off",
-                "@typescript-eslint/no-unused-vars": "off"
+                "@typescript-eslint/no-unused-vars": "off",
+                "@typescript-eslint/no-use-before-define": "off",
+
+                /**
+                 * NOTE: Default props for functional components are to be deprecated (https://github.com/reactjs/rfcs/pull/107)
+                 * and are optional for class components due to TypeScript
+                 */
+                "react/require-default-props": "off"
             }
         }
     ]


### PR DESCRIPTION
This PR disables the following rules in TS files:
1. https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-default-props.md
    See the discussion in https://github.com/cloudify-cosmo/cloudify-ui-components/pull/58#discussion_r581928254 for the reasoning
2. https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md
    This rule is superseded by TypeScript, which already checks that variables need to be defined before using them (see [the playground I prepared](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAJQKYEMDG8BmUIjgcilQ3wG4AoczAVwDsNgJa4BhAC2ABsATAISUzQkACgCUcAN7k4MuERjUozADzdgANwB8-QUWUB6NVvIBfcmiYBneOpRRgKAEackOoXAC8BRwKFlKVHQMTHAACnZItDBiktKyFrSWEC4AdJwQAObCtvZOLm5EADRwOQ7OSACCmDBIUKIUsnD6+nAAAjCWALRIAB5gSBjdUDhQcTIJSanpWaV5SACStADKKCBISxb9vNQwVTV1DfFWNnZlLosraxsQWzt7tZ4ElmwQ1DxwPnDAtLacwNz+MZyJAKJRwYTKTRAmTKdhcPi+IhNKGNGFwnj3KDI6FwAyaeqmSgTE65cqYx74FDVWqAmj0GCMZjo7iYmJSRryRQqIyaTEGHkUExAA)). This rule resulted in false-positives, e.g. not being able to use function components defined later on in the file using `const` (to be able to annotate them)
3. https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md
    Taken care of by TS. See https://github.com/cloudify-cosmo/cloudify-stage/blob/b2099a645c30427078745ad6bf11858fb3d63205/widgets/deploymentsView/src/columns.tsx#L73 for a place when it's a false-positive