### PR TITLE
RD-1748 Fix no-shadow rule in TypeScript files

### DIFF
--- a/configs/eslint-ts-overrides.json
+++ b/configs/eslint-ts-overrides.json
@@ -23,7 +23,11 @@
             { "functions": false, "classes": true, "variables": true }
         ],
 
-        "@typescript-eslint/no-empty-function": "off"
+        "@typescript-eslint/no-empty-function": "off",
+
+        // See https://github.com/typescript-eslint/typescript-eslint/issues/2483
+        "no-shadow": "off",
+        "@typescript-eslint/no-shadow": "error"
     },
     "settings": {
         "import/resolver": {


### PR DESCRIPTION
no-shadow rule resulted in false-positives for TS `enum`s

@typescript-eslint/no-shadow should be used instead.

See https://github.com/typescript-eslint/typescript-eslint/issues/2483

I'll release a minor version of this repo after merging this PR :slightly_smiling_face: 