### PR TITLE
RD-2917 Updated logger implementation to prevent recursive loops

### DIFF
--- a/backend/logger.js
+++ b/backend/logger.js
@@ -96,6 +96,10 @@ function initLogging(config, defaultMaxListeners = 30) {
      * @returns {Object} winston logger instance
      */
     function getLogger(category) {
+        if (winston.loggers.has(category)) {
+            return winston.loggers.get(category);
+        }
+
         const logger = winston.loggers.add(category, {
             level,
             transports,

--- a/backend/test/logger.test.js
+++ b/backend/test/logger.test.js
@@ -108,4 +108,12 @@ describe('logger', () => {
         logger.info(bigInt);
         expect(console.log).toHaveBeenLastCalledWith(expect.stringContaining('<NotParsable>'));
     });
+
+    it('should have consistent instances when obtained multiple times', () => {
+        const loggerFactory = initLogging(commonConfig);
+        const loggingFunction = loggerFactory.getLogger('sample').info;
+        const loggingFunctionSameLoggerDifferentGet = loggerFactory.getLogger('sample').info;
+
+        expect(loggingFunction).toBe(loggingFunctionSameLoggerDifferentGet);
+    });
 });


### PR DESCRIPTION
<!--- Provide JIRA issue ID and a general summary of your changes in the Title above -->

## Description
With preexisting implementation each call to `getLogger` for the same category was adding a single recursive call loop to each of logging functions (`info`, `error` etc.), eventually leading to stack overflow. This PR fixes the issue.
<!--- Describe your changes to help reviewers understand the details. -->

## Screenshots / Videos
N/A

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [X] I verified if that change requires a documentation update.
- [X] I added proper labels to this PR.

## Tests
Added test case which was failing before the fix and now passes.

## Documentation
N/A