### PR TITLE
RD-381 Upgrade Sequelize to version 6 and refactor DB Initializer

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -32,7 +32,7 @@ Constructs new object containing `init` function and `db` object
     *   `dbConfig.url` **([string][16] | [Array][17])** DB connection URL or an array of URLs
     *   `dbConfig.options` **[Object][15]** DB connection options
 *   `loggerFactory` **[Object][15]** object containing `getLogger` function
-*   `modelFns` **[Array][17]<(function (Sequelize, Sequelize.DataTypes): Sequelize.Model)>** array of functions returning sequelize model
+*   `models` **[Array][17]<(function (Sequelize, Sequelize.DataTypes): Sequelize.Model)>** array of functions returning sequelize model
 
 ### init
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -32,9 +32,7 @@ Constructs new object containing `init` function and `db` object
     *   `dbConfig.url` **([string][16] | [Array][17])** DB connection URL or an array of URLs
     *   `dbConfig.options` **[Object][15]** DB connection options
 *   `loggerFactory` **[Object][15]** object containing `getLogger` function
-*   `modelsDir` **[string][16]** directory for models lookup
-*   `modelExcludes` **[Array][17]** list of files to be excluded from model definitions discovered by reading models
-    directory as specified by `modelsDir` argument (optional, default `[]`)
+*   `modelFns` **[Array][17]<(function (Sequelize, Sequelize.DataTypes): Sequelize.Model)>** array of functions returning sequelize model
 
 ### init
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -32,7 +32,7 @@ Constructs new object containing `init` function and `db` object
     *   `dbConfig.url` **([string][16] | [Array][17])** DB connection URL or an array of URLs
     *   `dbConfig.options` **[Object][15]** DB connection options
 *   `loggerFactory` **[Object][15]** object containing `getLogger` function
-*   `models` **[Array][17]<(function (Sequelize, Sequelize.DataTypes): Sequelize.Model)>** array of functions returning sequelize model
+*   `modelFactories` **[Array][17]<(function (Sequelize, Sequelize.DataTypes): Sequelize.Model)>** array of factory functions returning sequelize model
 
 ### init
 

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const fs = require('fs');
-const path = require('path');
 const request = require('request');
 const Sequelize = require('sequelize');
 
@@ -41,21 +40,15 @@ function addHooks(sequelize, restart) {
  * @param {string | Array} dbConfig.url DB connection URL or an array of URLs
  * @param {Object} dbConfig.options DB connection options
  * @param {Object} loggerFactory object containing `getLogger` function
- * @param {(function(Sequelize, Sequelize.DataTypes): Sequelize.Model)[]} modelFns array of functions returning sequelize model
+ * @param {(function(Sequelize, Sequelize.DataTypes): Sequelize.Model)[]} models array of functions returning sequelize model
  */
-function DbInitializer(dbConfig, loggerFactory, modelFns) {
+function DbInitializer(dbConfig, loggerFactory, models) {
     const logger = loggerFactory.getLogger('DBConnection');
 
-    function getModelName(model) {
-        const modelTableName = model.getTableName();
-        return typeof modelTableName === 'string' ? modelTableName : modelTableName.tableName;
-    }
-
     function addModels(sequelize) {
-        modelFns.forEach(modelFn => {
-            const model = modelFn(sequelize, Sequelize.DataTypes);
-            const name = getModelName(model);
-            db[name] = model;
+        models.forEach(getModel => {
+            const model = getModel(sequelize, Sequelize.DataTypes);
+            db[model.name] = model;
         });
     }
 

--- a/backend/db.js
+++ b/backend/db.js
@@ -40,14 +40,14 @@ function addHooks(sequelize, restart) {
  * @param {string | Array} dbConfig.url DB connection URL or an array of URLs
  * @param {Object} dbConfig.options DB connection options
  * @param {Object} loggerFactory object containing `getLogger` function
- * @param {(function(Sequelize, Sequelize.DataTypes): Sequelize.Model)[]} models array of functions returning sequelize model
+ * @param {(function(Sequelize, Sequelize.DataTypes): Sequelize.Model)[]} modelFactories array of factory functions returning sequelize model
  */
-function DbInitializer(dbConfig, loggerFactory, models) {
+function DbInitializer(dbConfig, loggerFactory, modelFactories) {
     const logger = loggerFactory.getLogger('DBConnection');
 
     function addModels(sequelize) {
-        models.forEach(getModel => {
-            const model = getModel(sequelize, Sequelize.DataTypes);
+        modelFactories.forEach(modelFactory => {
+            const model = modelFactory(sequelize, Sequelize.DataTypes);
             db[model.name] = model;
         });
     }

--- a/backend/test/db.test.js
+++ b/backend/test/db.test.js
@@ -14,10 +14,10 @@ fs.readFileSync.mockImplementation(_.constant(fileContent));
 
 describe('db init', () => {
     const model = { name: 'modelName' };
+    const models = [() => model];
 
     function mockSequelize() {
         const sequelizeMock = {
-            import: _.constant(model),
             afterDisconnect: jest.fn(),
             beforeQuery: jest.fn(),
             close: jest.fn(),
@@ -58,7 +58,7 @@ describe('db init', () => {
         const initializer = new DbInitializer(
             getOptions('postgres://url', { cert: 'certPath', ca: 'caPath' }),
             logger,
-            '.'
+            models
         );
         return initializer.init().then(() => {
             expect(sequelizeMock.beforeQuery).toHaveBeenCalled();
@@ -83,7 +83,7 @@ describe('db init', () => {
 
     it('should handle string url and connection success', () => {
         const sequelizeMock = mockSequelize();
-        const initializer = new DbInitializer(getOptions('postgres://url', { ca: 'caPath' }), mockLogger(), '.');
+        const initializer = new DbInitializer(getOptions('postgres://url', { ca: 'caPath' }), mockLogger(), models);
         return initializer.init().then(() => {
             expect(sequelizeMock.beforeQuery).toHaveBeenCalled();
             expect(sequelizeMock.afterDisconnect).toHaveBeenCalled();
@@ -93,7 +93,7 @@ describe('db init', () => {
 
     it('should restart after disconnection', () => {
         const sequelizeMock = mockSequelize();
-        const initializer = new DbInitializer(getOptions('postgres://url', { ca: 'caPath' }), mockLogger(), '.');
+        const initializer = new DbInitializer(getOptions('postgres://url', { ca: 'caPath' }), mockLogger(), models);
         return initializer
             .init()
             .then(() => {
@@ -109,7 +109,7 @@ describe('db init', () => {
 
     it('should restart when PG is in recovery', () => {
         const sequelizeMock = mockSequelize();
-        const initializer = new DbInitializer(getOptions('postgres://url', { ca: 'caPath' }), mockLogger(), '.');
+        const initializer = new DbInitializer(getOptions('postgres://url', { ca: 'caPath' }), mockLogger(), models);
         return initializer
             .init()
             .then(() => {
@@ -133,7 +133,7 @@ describe('db init', () => {
     it('should handle array of URLs', () => {
         const sequelizeMock = mockSequelize();
         const url = 'postgres://url';
-        const initializer = new DbInitializer(getOptions([url], { ca: 'caPath' }), mockLogger(), '.');
+        const initializer = new DbInitializer(getOptions([url], { ca: 'caPath' }), mockLogger(), models);
         request.mockImplementationOnce((options, handler) => handler(true));
         request.mockImplementationOnce((options, handler) => handler(false, { statusCode: 200 }));
         return initializer.init().then(() => {

--- a/backend/test/db.test.js
+++ b/backend/test/db.test.js
@@ -14,7 +14,7 @@ fs.readFileSync.mockImplementation(_.constant(fileContent));
 
 describe('db init', () => {
     const model = { name: 'modelName' };
-    const models = [() => model];
+    const modelFactories = [() => model];
 
     function mockSequelize() {
         const sequelizeMock = {
@@ -58,7 +58,7 @@ describe('db init', () => {
         const initializer = new DbInitializer(
             getOptions('postgres://url', { cert: 'certPath', ca: 'caPath' }),
             logger,
-            models
+            modelFactories
         );
         return initializer.init().then(() => {
             expect(sequelizeMock.beforeQuery).toHaveBeenCalled();
@@ -83,7 +83,11 @@ describe('db init', () => {
 
     it('should handle string url and connection success', () => {
         const sequelizeMock = mockSequelize();
-        const initializer = new DbInitializer(getOptions('postgres://url', { ca: 'caPath' }), mockLogger(), models);
+        const initializer = new DbInitializer(
+            getOptions('postgres://url', { ca: 'caPath' }),
+            mockLogger(),
+            modelFactories
+        );
         return initializer.init().then(() => {
             expect(sequelizeMock.beforeQuery).toHaveBeenCalled();
             expect(sequelizeMock.afterDisconnect).toHaveBeenCalled();
@@ -93,7 +97,11 @@ describe('db init', () => {
 
     it('should restart after disconnection', () => {
         const sequelizeMock = mockSequelize();
-        const initializer = new DbInitializer(getOptions('postgres://url', { ca: 'caPath' }), mockLogger(), models);
+        const initializer = new DbInitializer(
+            getOptions('postgres://url', { ca: 'caPath' }),
+            mockLogger(),
+            modelFactories
+        );
         return initializer
             .init()
             .then(() => {
@@ -109,7 +117,11 @@ describe('db init', () => {
 
     it('should restart when PG is in recovery', () => {
         const sequelizeMock = mockSequelize();
-        const initializer = new DbInitializer(getOptions('postgres://url', { ca: 'caPath' }), mockLogger(), models);
+        const initializer = new DbInitializer(
+            getOptions('postgres://url', { ca: 'caPath' }),
+            mockLogger(),
+            modelFactories
+        );
         return initializer
             .init()
             .then(() => {
@@ -133,7 +145,7 @@ describe('db init', () => {
     it('should handle array of URLs', () => {
         const sequelizeMock = mockSequelize();
         const url = 'postgres://url';
-        const initializer = new DbInitializer(getOptions([url], { ca: 'caPath' }), mockLogger(), models);
+        const initializer = new DbInitializer(getOptions([url], { ca: 'caPath' }), mockLogger(), modelFactories);
         request.mockImplementationOnce((options, handler) => handler(true));
         request.mockImplementationOnce((options, handler) => handler(false, { statusCode: 200 }));
         return initializer.init().then(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6397,7 +6397,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -6704,6 +6708,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "blob-util": {
       "version": "2.0.2",
@@ -7480,15 +7494,6 @@
         "inherits": "^2.0.1",
         "process-nextick-args": "^2.0.0",
         "readable-stream": "^2.3.5"
-      }
-    },
-    "cls-bluebird": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
-      "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
-      "requires": {
-        "is-bluebird": "^1.0.2",
-        "shimmer": "^1.1.0"
       }
     },
     "co": {
@@ -10802,6 +10807,13 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -11999,9 +12011,9 @@
       "dev": true
     },
     "inflection": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
-      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.1.tgz",
+      "integrity": "sha512-dldYtl2WlN0QDkIDtg8+xFwOS2Tbmp12t1cHa5/YClU6ZQjTFm7B66UcVbh9NQB+HvT5BAd2t5+yKsBkw5pcqA=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -12137,11 +12149,6 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
-    },
-    "is-bluebird": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
-      "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI="
     },
     "is-boolean-object": {
       "version": "1.1.1",
@@ -17401,7 +17408,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -18157,9 +18163,9 @@
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "moment-timezone": {
-      "version": "0.5.32",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.32.tgz",
-      "integrity": "sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==",
+      "version": "0.5.33",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
       "requires": {
         "moment": ">= 2.9.0"
       }
@@ -18168,6 +18174,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.23",
@@ -20123,43 +20136,39 @@
       "dev": true
     },
     "sequelize": {
-      "version": "5.22.3",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.22.3.tgz",
-      "integrity": "sha512-+nxf4TzdrB+PRmoWhR05TP9ukLAurK7qtKcIFv5Vhxm5Z9v+d2PcTT6Ea3YAoIQVkZ47QlT9XWAIUevMT/3l8Q==",
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.6.5.tgz",
+      "integrity": "sha512-QyRrJrDRiwuiILqTMHUA1yWOPIL12KlfmgZ3hnzQwbMvp2vJ6fzu9bYJQB+qPMosck4mBUggY4Cjoc6Et8FBIQ==",
       "requires": {
-        "bluebird": "^3.5.0",
-        "cls-bluebird": "^2.1.0",
         "debug": "^4.1.1",
         "dottie": "^2.0.0",
-        "inflection": "1.12.0",
-        "lodash": "^4.17.15",
-        "moment": "^2.24.0",
-        "moment-timezone": "^0.5.21",
+        "inflection": "1.13.1",
+        "lodash": "^4.17.20",
+        "moment": "^2.26.0",
+        "moment-timezone": "^0.5.31",
         "retry-as-promised": "^3.2.0",
-        "semver": "^6.3.0",
-        "sequelize-pool": "^2.3.0",
+        "semver": "^7.3.2",
+        "sequelize-pool": "^6.0.0",
         "toposort-class": "^1.0.1",
-        "uuid": "^3.3.3",
-        "validator": "^10.11.0",
-        "wkx": "^0.4.8"
+        "uuid": "^8.1.0",
+        "validator": "^13.6.0",
+        "wkx": "^0.5.0"
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
     "sequelize-pool": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
-      "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-6.1.0.tgz",
+      "integrity": "sha512-4YwEw3ZgK/tY/so+GfnSgXkdwIJJ1I32uZJztIEgZeAO6HMgj64OzySbWLgxj+tXhZCJnzRfkY9gINw8Ft8ZMg=="
     },
     "serialize-javascript": {
       "version": "4.0.0",
@@ -20266,11 +20275,6 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
-    },
-    "shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "side-channel": {
       "version": "1.0.4",
@@ -21839,9 +21843,7 @@
     "uuid": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",
@@ -21879,9 +21881,9 @@
       }
     },
     "validator": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
     },
     "value-or-function": {
       "version": "3.0.0",
@@ -22110,7 +22112,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -22295,9 +22301,9 @@
       }
     },
     "wkx": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
-      "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
       "requires": {
         "@types/node": "*"
       }
@@ -22411,8 +22417,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "eslint-config-prettier": "^6.12.0",
         "lodash": "^4.17.21",
         "request": "^2.88.2",
-        "sequelize": "^5.22.3",
+        "sequelize": "^6.6.5",
         "umzug": "^1.12.0",
         "winston": "^3.3.3"
     },


### PR DESCRIPTION
## Description
This PR upgrades Sequelize to version 6. As `sequelize.import` method has been removed, DB Initializer had to be updated not to get a directory containing models and potential excludes, but already imported model files (by model files I understand files exporing a function with such signature: `function(sequelize: Sequelize, dataTypes: Sequelize.DataTypes): Sequelize.Model`).

Once this PR is merged I'm planning to release new major version: `5.0.0`.
Then the following PRs can be updated:
1. Stage - https://github.com/cloudify-cosmo/cloudify-stage/pull/1623
2. Composer - https://github.com/cloudify-cosmo/cloudify-blueprint-composer/pull/929

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
1. Unit tests updated and passing.
2. Stage - tested internally, seems working good, but I didn't yet run all system tests.
3. Composer - tested internally, seems working good, only DB initializer changes required, not yet system tested.

Will run Stage and Composer system tests once we have new `cloudify-ui-common` version released.

## Documentation
N/A