### PR TITLE
RD-3222 Improve relationships between ESLint configs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-    "extends": ["plugin:jsdoc/recommended", "./configs/eslint-common.json"],
+    "extends": ["plugin:jsdoc/recommended", "./configs/eslint-common-node.json"],
     "rules": {
         "jsdoc/require-jsdoc": [
             "error",

--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -2,8 +2,6 @@
     "extends": ["../configs/eslint-common-node.json"],
     "rules": {
         // NOTE: packageDir is relative to the current working directory when executing linter
-        "import/no-extraneous-dependencies": ["error", { "packageDir": "./" }],
-        // NOTE: handled by import/no-extraneous-dependencies
-        "node/no-extraneous-require": "off"
+        "import/no-extraneous-dependencies": ["error", { "packageDir": "./" }]
     }
 }

--- a/configs/README.md
+++ b/configs/README.md
@@ -9,23 +9,25 @@ ESLint configs should be extended by every cloudify-ui project/module.
 
 #### Usage
 
-Once `cloudify-ui-common` is installed as a dependency it is required to modify project's ESLint config (most probably `.eslintrc` or `.eslintrc.json` file) by adding the following entry (assuming ESLint config file is located in top level directory and it is a non-react project):
+Once `cloudify-ui-common` is installed as a dependency it is required to modify project's ESLint config (most probably `.eslintrc` or `.eslintrc.json` file) by adding the following entry (assuming ESLint config file is located in top level directory and it is a React project):
 ```json
 {
-  "extends": ["./node_modules/cloudify-ui-common/configs/eslint-common.json"]
+  "extends": ["./node_modules/cloudify-ui-common/configs/eslint-common-react.json"]
 }
 ```
 It is also required to install peer dependencies as specified in `package.json`.
-There are three configuration files that can be extended.
-The table below describes their purpose and dependencies necessary to be installed prior using each configuration file.  
+There are few configuration files that can be extended.
+The table below describes their purpose and dependencies necessary to be installed prior using each configuration file.
 
-| Configuration file           | Used for                  | Dependencies |
-|---                           |---                        |---|
-| `eslint-ts-overrides.json`   | TypeScript-based projects | `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser` |
-| `eslint-common.json`         | non-react common projects | `eslint`, `eslint-config-prettier`, `eslint-plugin-import`, `eslint-plugin-prettier`, `eslint-plugin-scanjs-rules`, `eslint-plugin-security` |
-| `eslint-common-react.json`   | react-based projects      | all from `eslint-common.json` and `eslint-plugin-react`, `eslint-plugin-react-hooks`, `eslint-plugin-jsx-a11y` |
-| `eslint-common-node.json`    | node-based projects       | all from `eslint-common.json`, `eslint-plugin-node` |
-| `eslint-common-cypress.json` | Cypress subprojects       | `eslint`, `eslint-plugin-cypress`, `eslint-plugin-chai-friendly` |
+Note: `eslint-common.json` does not extends AirBnB ESLint configuration, so it should not be used alone in the UI projects.
+
+| Configuration file           | Used for                  | Dependencies                                                                                                                              |
+|---                           |---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `eslint-ts-overrides.json`   | TypeScript-based projects | `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`                                                                           |
+| `eslint-common.json`         | a base for other configs  | `eslint`, `eslint-config-prettier`, `eslint-plugin-import`, `eslint-plugin-prettier`, `eslint-plugin-scanjs-rules`, `eslint-plugin-security` |
+| `eslint-common-react.json`   | React-based projects      | all from `eslint-config-airbnb` and `eslint-common.json` and `eslint-plugin-react`, `eslint-plugin-react-hooks`, `eslint-plugin-jsx-a11y` |
+| `eslint-common-node.json`    | Node-based projects       | all from `eslint-config-airbnb-base` and `eslint-common.json`, `eslint-plugin-node`                                                       |
+| `eslint-common-cypress.json` | Cypress subprojects       | all from `eslint-config-airbnb-base` and `eslint-common.json`, `eslint-plugin-cypress`, `eslint-plugin-chai-friendly`                     |
 
 
 ### TypeScript

--- a/configs/eslint-common-cypress.json
+++ b/configs/eslint-common-cypress.json
@@ -1,6 +1,13 @@
 {
-    "extends": ["plugin:chai-friendly/recommended", "plugin:cypress/recommended"],
-
+    "extends": [
+        "airbnb-base",
+        "./eslint-common.json",
+        "plugin:chai-friendly/recommended",
+        "plugin:cypress/recommended"
+    ],
+    "rules": {
+        "import/no-extraneous-dependencies": "off"
+    },
     "env": {
         "cypress/globals": true
     },

--- a/configs/eslint-common-node.json
+++ b/configs/eslint-common-node.json
@@ -1,5 +1,19 @@
 {
-    "extends": ["plugin:node/recommended", "./eslint-common.json"],
+    "extends": [
+        "airbnb-base",
+        "./eslint-common.json",
+        "plugin:node/recommended"
+    ],
+    "rules": {
+        "node/no-unsupported-features/es-syntax": "off",
+        // NOTE: handled by import/no-extraneous-dependencies
+        "node/no-extraneous-require": "off"
+    },
+    "settings": {
+        "node": {
+            "tryExtensions": [".js", ".json", ".ts"]
+        }
+    },
     "env": {
         "node": true
     }

--- a/configs/eslint-common-react.json
+++ b/configs/eslint-common-react.json
@@ -1,8 +1,8 @@
 {
     "extends": [
         "airbnb",
-        "prettier/react",
-        "./eslint-common.json"
+        "./eslint-common.json",
+        "prettier/react"
     ],
     "rules": {
         "react/jsx-props-no-spreading": "off",

--- a/configs/eslint-common-react.json
+++ b/configs/eslint-common-react.json
@@ -1,10 +1,8 @@
 {
     "extends": [
-        "./eslint-common.json",
         "airbnb",
         "prettier/react",
-        "plugin:prettier/recommended",
-        "./eslint-ts-overrides.json"
+        "./eslint-common.json"
     ],
     "rules": {
         "react/jsx-props-no-spreading": "off",

--- a/configs/eslint-common.json
+++ b/configs/eslint-common.json
@@ -57,7 +57,7 @@
     },
     "overrides": [
         {
-            "files": ["*.ts"],
+            "files": ["*.ts", "*.tsx"],
             "rules": {
                 "import/prefer-default-export": "off"
             }

--- a/configs/eslint-common.json
+++ b/configs/eslint-common.json
@@ -57,7 +57,7 @@
     },
     "overrides": [
         {
-            "files": ["*.ts", "*.tsx"],
+            "files": ["*.ts"],
             "rules": {
                 "import/prefer-default-export": "off"
             }

--- a/configs/eslint-common.json
+++ b/configs/eslint-common.json
@@ -1,7 +1,6 @@
 {
     "parser": "@typescript-eslint/parser",
     "extends": [
-        "airbnb-base",
         "plugin:prettier/recommended",
         "plugin:security/recommended",
         "./eslint-ts-overrides.json"


### PR DESCRIPTION
## Description
Changed ESLint common configurations to allow easier overriding:
1. Make `eslint-common` as a base for all, with an intention not to use it directly (with only one exception: `cloudify-blueprint-topology`)
2. Make all ESLint configurations to base either on `airbnb` (React) or `airbnb-base` (non-React)
3. Fix minor issues inside configs (see comments)

The following changes are necessary in the other repositories:
1. https://github.com/cloudify-cosmo/cloudify-ui-components/pull/123 
2. https://github.com/cloudify-cosmo/cloudify-blueprint-topology/pull/188
3. https://github.com/cloudify-cosmo/cloudify-blueprint-composer/pull/960
4. https://github.com/cloudify-cosmo/cloudify-stage/pull/1796 


## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
CI pipeline is green.

In all the branches created for the following PRs: 
    1. https://github.com/cloudify-cosmo/cloudify-ui-components/pull/123 
    2. https://github.com/cloudify-cosmo/cloudify-blueprint-topology/pull/188
    3. https://github.com/cloudify-cosmo/cloudify-blueprint-composer/pull/960
    4. https://github.com/cloudify-cosmo/cloudify-stage/pull/1796 

did the following
```
npm link ../cloudify-ui-common
npm run lint
```
In all cases it was passing.

## Documentation
Updated `configs/README.md`.