### PR TITLE
RD-4422 Change token endpoint in getAdminToken Cypress command

### DIFF
--- a/cypress/src/support/index.ts
+++ b/cypress/src/support/index.ts
@@ -27,11 +27,15 @@ const commands = {
     getAdminToken: () =>
         cy
             .request({
-                method: 'GET',
+                method: 'POST',
                 url: '/console/sp/tokens',
                 headers: {
                     Authorization: `Basic ${btoa('admin:admin')}`,
                     'Content-Type': 'application/json'
+                },
+                body: {
+                    description: 'UI tests authentication token',
+                    expiration_date: '+10h'
                 }
             })
             .then(response => response.body.value)


### PR DESCRIPTION
## Description
As part of RD-4412, there was a change in the `/tokens` API (`GET` -> `POST` and payload added).
This change is to adapt Cypress test code to that change.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
TODO

## Documentation
N/A