### PR TITLE
RD-4447 Fix logger call in migration script

### DIFF
--- a/backend/migration.ts
+++ b/backend/migration.ts
@@ -90,7 +90,7 @@ function runMigration(loggerFactory: LoggerFactory, dbModule: DbModule): void {
 
         function logUmzugEvent(eventName: string) {
             return (eventData: any) => {
-                logger.info(`${eventName}: ${eventData}`);
+                logger.info(`${eventName}:`, eventData);
             };
         }
         umzug.on('migrating', logUmzugEvent('migrating'));


### PR DESCRIPTION
## Description

This PR introduces a simple fix to make logs more informative:

### Before
```
[2022-03-09T11:06:09.554Z][DBMigration] INFO: migrated: [object Object]
```
### After
```
[2022-03-09T11:01:57.640Z][DBMigration] INFO: migrated: {"name":"20210929110911-6_3-UserAppsPageGroups.js","path":"/**/cloudify-stage/backend/migrations/20210929110911-6_3-UserAppsPageGroups.ts","context":{}}

```

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Tested locally in Stage.

## Documentation
N/A