### PR TITLE
RD-4450 Fix Patroni URL requests in DB module

### DIFF
--- a/backend/db.ts
+++ b/backend/db.ts
@@ -102,7 +102,7 @@ function getDbModule(dbConfig: DbConfig, loggerFactory: LoggerFactory, modelFact
             return axios(patroniUrl)
                 .then(response => response.status === 200)
                 .catch(error => {
-                    logger.debug(`Error occured when requesting: ${url}.`, error);
+                    logger.error(`Error occured when requesting: ${patroniUrl}.`, error);
                     return false;
                 });
         }

--- a/backend/db.ts
+++ b/backend/db.ts
@@ -109,14 +109,14 @@ function getDbModule(dbConfig: DbConfig, loggerFactory: LoggerFactory, modelFact
         function getHostname(dbUrl: string) {
             return new URL(dbUrl).hostname;
         }
-        function getCAFile() {
+        function getCertificateAuthority() {
             const { dialectOptions } = dbConfig.options;
             return dialectOptions?.ssl ? readFileSync(dialectOptions.ssl.ca, { encoding: 'utf8' }) : undefined;
         }
         function isResponding(url: string) {
             const patroniUrl = `https://${getHostname(url)}:8008`;
-            const caFile = getCAFile();
-            const config = caFile ? { httpsAgent: new https.Agent({ ca: caFile }) } : undefined;
+            const ca = getCertificateAuthority();
+            const config = ca ? { httpsAgent: new https.Agent({ ca }) } : undefined;
 
             return axios(patroniUrl, config)
                 .then(response => response.status === 200)

--- a/backend/test/db.test.ts
+++ b/backend/test/db.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import _ from 'lodash';
 import Sequelize from 'sequelize';
 import type { ModelStatic } from 'sequelize';
-import getDbModule from '../db';
+import getDbModule, { DialectOptions } from '../db';
 import type { DbConfig } from '../db';
 import type { LoggerFactory } from '../logger';
 import toMock from './toMock';
@@ -37,7 +37,7 @@ describe('db init', () => {
         };
     }
 
-    function getOptions(url: string | string[] = '', ssl = { ca: 'ca', cert: 'cert', key: 'key' }): DbConfig {
+    function getOptions(url: string | string[] = '', ssl: DialectOptions['ssl'] = { ca: 'ca' }): DbConfig {
         return {
             url,
             options: {
@@ -65,7 +65,10 @@ describe('db init', () => {
         const sequelizeMock = mockSequelize();
         sequelizeMock.authenticate.mockImplementation(async () => Promise.reject(new Error('Cannot connect')));
         const logger = mockLogger();
-        const dbModule = getDbModuleWithMockedLogger(getOptions('postgres://url'), logger);
+        const dbModule = getDbModuleWithMockedLogger(
+            getOptions('postgres://url', { ca: 'caPath', cert: 'certPath', key: 'keyPath' }),
+            logger
+        );
         return dbModule.init().then(() => {
             expect(sequelizeMock.beforeQuery).toHaveBeenCalled();
             expect(sequelizeMock.afterDisconnect).toHaveBeenCalled();
@@ -148,7 +151,7 @@ describe('db init', () => {
             })
         });
         const expectedSequelizeOptions = expect.objectContaining({
-            dialectOptions: { ssl: { ca: 'fileContent', cert: 'fileContent', key: 'fileContent' } },
+            dialectOptions: { ssl: { ca: 'fileContent' } },
             logging: expect.any(Function)
         });
 


### PR DESCRIPTION
## Description

It turned out that we need to pass CA to Patroni URL request.

Before `cloudify-ui-common` v6 we were using `request` package with `strictSSL: false`. 
After switching to `axios` it must be adjusted to pass CA properly instead of ignoring SSL.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Updated tests. 
Did manual tests in real cluster environment.

## Documentation
N/A