### PR TITLE
RD-3155 Add script to get TS migration progress

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,6 +4,10 @@
 
 Provides helper function for creating new version of NPM package by creating a new branch with version change commit and pushing that branch to the remote repository.
 
+### get-ts-migration-progress.sh
+
+Prints the summary of the migration to TypeScript.
+
 ### upload-package.sh
 
 Provides helper function for uploading package file to the remote machine using SSH and running specified command remotely.

--- a/scripts/get-ts-migration-progress.sh
+++ b/scripts/get-ts-migration-progress.sh
@@ -35,7 +35,8 @@ TOTAL_FILES_COUNT=$(($JS_FILES_COUNT+$TS_FILES_COUNT))
 function print_summary {
     local name=$1
     local files_count=$2
-    echo "$name: $files_count / $TOTAL_FILES_COUNT (`bc <<< "scale=2; $files_count * 100 / $TOTAL_FILES_COUNT"`%)"
+    local percentage=`awk -- 'BEGIN{printf "%.2f\n", ARGV[1]/ARGV[2]*100}' "$files_count" "$TOTAL_FILES_COUNT"`
+    echo "$name: $files_count / $TOTAL_FILES_COUNT ($percentage%)"
 }
 
 TS_FULLY_MIGRATED_COUNT=$(($TS_FILES_COUNT - $TS_NOCHECK_COUNT))

--- a/scripts/get-ts-migration-progress.sh
+++ b/scripts/get-ts-migration-progress.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#===================================================================================
+# Usage:
+#   get-ts-migration-progress [list of directories to check]
+#
+# Description:
+#   Prints the summary of the migration to TypeScript.
+#
+# Arguments:
+#   $1 (directories to check) - by default check is executed in the current directory
+#
+#===================================================================================
+
+DIRECTORIES_TO_CHECK=${1:-.}
+echo "Inspecting files in directories: $DIRECTORIES_TO_CHECK"
+
+JS_FILES_COUNT=`find $DIRECTORIES_TO_CHECK -type f \( -name '*.js' -o -name '*.jsx' \) ! -path '*node_modules*' ! \
+-name '*.config.js' ! -path '*/.*' | wc -l`
+echo "Found $JS_FILES_COUNT JS/JSX files"
+
+TS_FILES=`find $DIRECTORIES_TO_CHECK -type f \( -name '*.ts' -o -name '*.tsx' \) ! -path '*node_modules*'`
+TS_FILES_COUNT=`echo "$TS_FILES" | sed -r '/^\s*$/d' | wc -l`
+echo "Found $TS_FILES_COUNT TS/TSX files"
+if test $TS_FILES_COUNT -gt 0; then
+    TS_NOCHECK_COUNT=`grep '@ts-nocheck' $TS_FILES | wc -l || true`
+    echo "$TS_NOCHECK_COUNT out of these TS/TSX files have a '@ts-nocheck' header"
+else
+    TS_NOCHECK_COUNT=0
+fi
+
+TOTAL_FILES_COUNT=$(($JS_FILES_COUNT+$TS_FILES_COUNT))
+
+function print_summary {
+    local name=$1
+    local files_count=$2
+    echo "$name: $files_count / $TOTAL_FILES_COUNT (`bc <<< "scale=2; $files_count * 100 / $TOTAL_FILES_COUNT"`%)"
+}
+
+TS_FULLY_MIGRATED_COUNT=$(($TS_FILES_COUNT - $TS_NOCHECK_COUNT))
+printf "\nSummary:\n"
+print_summary "JS/JSX" $JS_FILES_COUNT
+print_summary "TS/TSX" $TS_FILES_COUNT
+print_summary "Fully migrated TS/TSX" $TS_FULLY_MIGRATED_COUNT


### PR DESCRIPTION
## Description

Moved [getTsMigrationProgress.sh](https://github.com/cloudify-cosmo/cloudify-stage/blob/b8ce77573141631234b8eb3ad401c6d4e99ed4bb/scripts/getTsMigrationProgress.sh) from `cloudify-stage` and improved it a bit to allow migration status checks in other UI repositories.

Example:

```
# ./cloudify-ui-common/scripts/get-ts-migration-progress.sh cloudify-ui-components

Inspecting files in directories: cloudify-ui-components
Found 158 JS/JSX files
Found 32 TS/TSX files
0 out of these TS/TSX files have a '@ts-nocheck' header

Summary:
JS/JSX: 158 / 190 (83.15%)
TS/TSX: 32 / 190 (16.84%)
Fully migrated TS/TSX: 32 / 190 (16.84%)
```

I'm planning to integrate it with UI nightly build as part of https://github.com/cloudify-cosmo/cloudify-build-system/pull/636 .

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Did manual tests. Seems all working fine.

## Documentation
Updated.