### PR TITLE
RD-5435 Bump `sequelize` package to v6.21.3

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "axios": "^0.26.0",
         "lodash": "^4.17.21",
-        "sequelize": "^6.6.5",
+        "sequelize": "^6.21.3",
         "umzug": "^3.0.0",
         "winston": "^3.3.3"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "eslint-config-airbnb-base": "^14.2.1",
                 "eslint-config-prettier": "^6.12.0",
                 "lodash": "^4.17.21",
-                "sequelize": "^6.19.1",
+                "sequelize": "^6.21.3",
                 "umzug": "^3.0.0",
                 "winston": "^3.3.3"
             },
@@ -21090,9 +21090,9 @@
             }
         },
         "node_modules/sequelize": {
-            "version": "6.19.1",
-            "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.19.1.tgz",
-            "integrity": "sha512-iTgi0y6q6XCFf2+Tzclhpe/EBVlCNOSl5fLNmquAmrgfOsDzEoPbceu0TXmrEe9osYHscX295awi0+dTDR1qzQ==",
+            "version": "6.21.3",
+            "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.21.3.tgz",
+            "integrity": "sha512-cJPrTTVCofUxaaNKoIETiXCYh2xJ+OFq5jMHJQqftp34M4kNoLpTfUMPSwYtRUeTcSh1/5HodfJXIBi7troIFA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -40040,9 +40040,9 @@
             "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
         },
         "sequelize": {
-            "version": "6.19.1",
-            "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.19.1.tgz",
-            "integrity": "sha512-iTgi0y6q6XCFf2+Tzclhpe/EBVlCNOSl5fLNmquAmrgfOsDzEoPbceu0TXmrEe9osYHscX295awi0+dTDR1qzQ==",
+            "version": "6.21.3",
+            "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.21.3.tgz",
+            "integrity": "sha512-cJPrTTVCofUxaaNKoIETiXCYh2xJ+OFq5jMHJQqftp34M4kNoLpTfUMPSwYtRUeTcSh1/5HodfJXIBi7troIFA==",
             "requires": {
                 "@types/debug": "^4.1.7",
                 "@types/validator": "^13.7.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "eslint-config-airbnb-base": "^14.2.1",
         "eslint-config-prettier": "^6.12.0",
         "lodash": "^4.17.21",
-        "sequelize": "^6.19.1",
+        "sequelize": "^6.21.3",
         "umzug": "^3.0.0",
         "winston": "^3.3.3"
     },


### PR DESCRIPTION
## Description

This PR bumps `sequelize` package version to the latest to fix [SQL Injection](http://security.snyk.io/vuln/SNYK-JS-SEQUELIZE-2959225) issue.

Once it is merged, I'm going to release new patch version of the `cloudify-ui-common` package.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
All local tests are passing. It's a minor version bump, so I don't expect big problems in Stage and Composer backends.

## Documentation
N/A