### PR TITLE
RD-5955 Update UI packages NPM publish mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ If you met all points from the checklist above, follow these steps:
 
 1. Provide version type and package name to `npm run publish`. For example:
 
-    * `npm run publish -- minor cypress` - to publish new minor version of `cloudify-ui-common-cypress` package
-    * `npm run publish -- prepatch scripts` - to publish new prerelease patch version of `cloudify-ui-common-scripts` 
+    * `npm run publish minor cypress` - to publish new minor version of `cloudify-ui-common-cypress` package
+    * `npm run publish prepatch scripts` - to publish new prerelease patch version of `cloudify-ui-common-scripts` 
       package
   
    It will create special branch, add commit to it containing version bump in `package*.json` files according to your 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,14 @@ This section is divided into two parts:
 
 If you met all points from the checklist above, follow these steps:
 
-1. According to [Semantic Versioning](https://semver.org/#summary) run one of the following scripts:
+1. Provide version type and package name to `npm run publish`. For example:
 
-    * `npm run publish:patch` for new patch version,
-    * `npm run publish:minor` for new minor version,
-    * `npm run publish:major` for new major version,
-
-   which will create special branch, add commit to it containing version bump in `package*.json` files according to your choice, tag the commit and push branch to remote. That should trigger Jenkins jobs finalizing publish.
+    * `npm run publish -- minor cypress` - to publish new minor version of `cloudify-ui-common-cypress` package
+    * `npm run publish -- prepatch scripts` - to publish new prerelease patch version of `cloudify-ui-common-scripts` 
+      package
+  
+   It will create special branch, add commit to it containing version bump in `package*.json` files according to your 
+   choice, tag the commit and push branch to remote. That should trigger Jenkins jobs finalizing publish.
 
 1. Check if Jenkins jobs were successful.
 

--- a/ci/publish-version.sh
+++ b/ci/publish-version.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-. scripts/create-version.sh
-
-createVersion "$@"

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -71,9 +71,7 @@ pipeline {
               sh "echo '//registry.npmjs.org/:_authToken=${env.NPM_TOKEN}' > .npmrc"
 
               echo "Publish package"
-              dir("${env.PACKAGE_PATH}") {
-                sh 'npm publish'
-              }
+              sh 'npm publish --workspace "${env.PACKAGE_PATH}"'
 
               echo "Setup git user"
               sh '''

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
   }
 
   environment {
-    MAIN_BRANCH = 'RD-5955'
+    MAIN_BRANCH = 'master'
     WORKSPACE = "${env.WORKSPACE}"
     BRANCH = "${env.BRANCH_NAME}"
     PROJECT = "cloudify-ui-common"

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -60,9 +60,6 @@ pipeline {
       when {
         expression { return env.BRANCH =~ /^publish_.*/ }
       }
-      environment{
-        PACKAGE_PATH = "packages/${sh(script:'echo ${BRANCH} | cut -d_ -f 2', returnStdout: true).trim()}"
-      }
       steps {
         container('node'){
           dir("${env.WORKSPACE}/${env.PROJECT}") {
@@ -71,7 +68,10 @@ pipeline {
               sh "echo '//registry.npmjs.org/:_authToken=${env.NPM_TOKEN}' > .npmrc"
 
               echo "Publish package"
-              sh 'npm publish --workspace "${env.PACKAGE_PATH}"'
+              sh '''
+                export PACKAGE_NAME=`echo ${BRANCH} | cut -d "_" -f 2`
+	            npm publish --workspace packages/${PACKAGE_NAME}
+	          '''
 
               echo "Setup git user"
               sh '''

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
         expression { return env.BRANCH =~ /^publish_.*/ }
       }
       environment{
-        PACKAGE_PATH = "packages/${sh(script:'echo ${env.BRANCH} | cut -d'_' -f 2', returnStdout: true).trim()}"
+        PACKAGE_PATH = "packages/${sh(script:'echo ${env.BRANCH} | cut -d\'_\' -f 2', returnStdout: true).trim()}"
       }
       steps {
         container('node'){

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
         expression { return env.BRANCH =~ /^publish_.*/ }
       }
       environment{
-        PACKAGE_PATH = "packages/${sh(script:'echo ${env.BRANCH} | cut -d\'_\' -f 2', returnStdout: true).trim()}"
+        PACKAGE_PATH = "packages/${sh(script:'echo ${BRANCH} | cut -d_ -f 2', returnStdout: true).trim()}"
       }
       steps {
         container('node'){

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
   }
 
   environment {
-    MAIN_BRANCH = 'master'
+    MAIN_BRANCH = 'RD-5955'
     WORKSPACE = "${env.WORKSPACE}"
     BRANCH = "${env.BRANCH_NAME}"
     PROJECT = "cloudify-ui-common"
@@ -58,7 +58,10 @@ pipeline {
     }
     stage('Deploy') {
       when {
-        expression { return env.BRANCH =~ /^publish-v.*/ }
+        expression { return env.BRANCH =~ /^publish_.*/ }
+      }
+      environment{
+        PACKAGE_PATH = "packages/${sh(script:'echo ${env.BRANCH} | cut -d'_' -f 2', returnStdout: true).trim()}"
       }
       steps {
         container('node'){
@@ -68,7 +71,9 @@ pipeline {
               sh "echo '//registry.npmjs.org/:_authToken=${env.NPM_TOKEN}' > .npmrc"
 
               echo "Publish package"
-              sh 'npm publish'
+              dir("${env.PACKAGE_PATH}") {
+                sh 'npm publish'
+              }
 
               echo "Setup git user"
               sh '''

--- a/package-lock.json
+++ b/package-lock.json
@@ -1345,6 +1345,7 @@
             "version": "7.17.2",
             "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.17.2.tgz",
             "integrity": "sha512-NcKtr2epxfIrNM4VOmPKO46TvDMCBhgi2CrSHaEarrz+Plk2K5r9QemmOFTGpZaoKnWoGH5MO+CzeRsih/Fcgg==",
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "core-js-pure": "^3.20.2",
@@ -1838,6 +1839,7 @@
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
             "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+            "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.1.1",
@@ -1857,6 +1859,7 @@
             "version": "13.11.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
             "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+            "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -1871,6 +1874,7 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -1882,6 +1886,7 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
             "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+            "dev": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.0",
                 "debug": "^4.1.1",
@@ -1894,7 +1899,8 @@
         "node_modules/@humanwhocodes/object-schema": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-            "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w=="
+            "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+            "dev": true
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -4339,7 +4345,8 @@
         "node_modules/@types/json5": {
             "version": "0.0.29",
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-            "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+            "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+            "dev": true
         },
         "node_modules/@types/lodash": {
             "version": "4.14.170",
@@ -4925,6 +4932,7 @@
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
             "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4936,6 +4944,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -5136,6 +5145,7 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
             "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.10.2",
@@ -5182,6 +5192,7 @@
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
             "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
@@ -5217,6 +5228,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
             "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+            "dev": true,
             "dependencies": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.1"
@@ -5232,6 +5244,7 @@
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
             "integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.0",
@@ -5274,6 +5287,7 @@
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
             "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+            "dev": true,
             "peer": true
         },
         "node_modules/astral-regex": {
@@ -5331,6 +5345,7 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
             "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
+            "dev": true,
             "peer": true,
             "engines": {
                 "node": ">=4"
@@ -5348,6 +5363,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
             "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
+            "dev": true,
             "peer": true
         },
         "node_modules/babel-eslint": {
@@ -6014,6 +6030,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -6581,7 +6598,8 @@
         "node_modules/confusing-browser-globals": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
-            "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA=="
+            "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
+            "dev": true
         },
         "node_modules/connect-history-api-fallback": {
             "version": "2.0.0",
@@ -6596,6 +6614,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
             "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6698,6 +6717,7 @@
             "version": "3.21.1",
             "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.21.1.tgz",
             "integrity": "sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==",
+            "dev": true,
             "hasInstallScript": true,
             "peer": true,
             "funding": {
@@ -7032,6 +7052,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
             "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+            "dev": true,
             "peer": true
         },
         "node_modules/dashdash": {
@@ -7092,7 +7113,8 @@
         "node_modules/deep-is": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
         },
         "node_modules/deepmerge": {
             "version": "4.2.2",
@@ -7424,6 +7446,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+            "dev": true,
             "dependencies": {
                 "esutils": "^2.0.2"
             },
@@ -7620,6 +7643,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
@@ -7628,6 +7652,7 @@
             "version": "1.19.1",
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
             "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "es-to-primitive": "^1.2.1",
@@ -7667,6 +7692,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
             "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dev": true,
             "dependencies": {
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
@@ -7710,6 +7736,7 @@
             "version": "7.32.0",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
             "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "7.12.11",
                 "@eslint/eslintrc": "^0.4.3",
@@ -7766,6 +7793,7 @@
             "version": "18.2.1",
             "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
             "integrity": "sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==",
+            "dev": true,
             "dependencies": {
                 "eslint-config-airbnb-base": "^14.2.1",
                 "object.assign": "^4.1.2",
@@ -7786,6 +7814,7 @@
             "version": "14.2.1",
             "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
             "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
+            "dev": true,
             "dependencies": {
                 "confusing-browser-globals": "^1.0.10",
                 "object.assign": "^4.1.2",
@@ -7799,24 +7828,11 @@
                 "eslint-plugin-import": "^2.22.1"
             }
         },
-        "node_modules/eslint-config-prettier": {
-            "version": "6.12.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.12.0.tgz",
-            "integrity": "sha512-9jWPlFlgNwRUYVoujvWTQ1aMO8o6648r+K7qU7K5Jmkbyqav1fuEZC0COYpGBxyiAJb65Ra9hrmFx19xRGwXWw==",
-            "dependencies": {
-                "get-stdin": "^6.0.0"
-            },
-            "bin": {
-                "eslint-config-prettier-check": "bin/cli.js"
-            },
-            "peerDependencies": {
-                "eslint": ">=3.14.1"
-            }
-        },
         "node_modules/eslint-import-resolver-node": {
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
             "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+            "dev": true,
             "dependencies": {
                 "debug": "^2.6.9",
                 "resolve": "^1.13.1"
@@ -7826,6 +7842,7 @@
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
             "dependencies": {
                 "ms": "2.0.0"
             }
@@ -7833,12 +7850,14 @@
         "node_modules/eslint-import-resolver-node/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
         },
         "node_modules/eslint-module-utils": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
             "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+            "dev": true,
             "dependencies": {
                 "debug": "^2.6.9",
                 "pkg-dir": "^2.0.0"
@@ -7851,6 +7870,7 @@
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
             "dependencies": {
                 "ms": "2.0.0"
             }
@@ -7858,7 +7878,8 @@
         "node_modules/eslint-module-utils/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
         },
         "node_modules/eslint-plugin-chai-friendly": {
             "version": "0.6.0",
@@ -7906,6 +7927,7 @@
         "node_modules/eslint-plugin-import": {
             "version": "2.22.1",
             "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+            "dev": true,
             "dependencies": {
                 "array-includes": "^3.1.1",
                 "array.prototype.flat": "^1.2.3",
@@ -7932,6 +7954,7 @@
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
             "dependencies": {
                 "ms": "2.0.0"
             }
@@ -7940,6 +7963,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
             "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+            "dev": true,
             "dependencies": {
                 "esutils": "^2.0.2",
                 "isarray": "^1.0.0"
@@ -7951,7 +7975,8 @@
         "node_modules/eslint-plugin-import/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
         },
         "node_modules/eslint-plugin-jest": {
             "version": "24.1.0",
@@ -8014,6 +8039,7 @@
             "version": "6.5.1",
             "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.5.1.tgz",
             "integrity": "sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==",
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.16.3",
@@ -8040,6 +8066,7 @@
             "version": "9.2.2",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true,
             "peer": true
         },
         "node_modules/eslint-plugin-node": {
@@ -8099,6 +8126,7 @@
             "version": "7.29.2",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.2.tgz",
             "integrity": "sha512-ypEBTKOy5liFQXZWMchJ3LN0JX1uPI6n7MN7OPHKacqXAxq5gYC30TdO7wqGYQyxD1OrzpobdHC3hDmlRWDg9w==",
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "array-includes": "^3.1.4",
@@ -8127,6 +8155,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
             "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
+            "dev": true,
             "peer": true,
             "engines": {
                 "node": ">=10"
@@ -8139,6 +8168,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "esutils": "^2.0.2"
@@ -8151,6 +8181,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
             "peer": true,
             "engines": {
                 "node": ">=4.0"
@@ -8160,6 +8191,7 @@
             "version": "2.0.0-next.3",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
             "integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "is-core-module": "^2.2.0",
@@ -8173,6 +8205,7 @@
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
             "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -8211,6 +8244,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
             "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+            "dev": true,
             "dependencies": {
                 "eslint-visitor-keys": "^1.1.0"
             },
@@ -8225,6 +8259,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
             "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -8233,6 +8268,7 @@
             "version": "7.12.11",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
             "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+            "dev": true,
             "dependencies": {
                 "@babel/highlight": "^7.10.4"
             }
@@ -8241,6 +8277,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -8256,6 +8293,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -8270,6 +8308,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -8281,6 +8320,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -8291,12 +8331,14 @@
         "node_modules/eslint/node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
         },
         "node_modules/eslint/node_modules/cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
             "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dev": true,
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -8310,6 +8352,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -8321,6 +8364,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
             "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             }
@@ -8329,6 +8373,7 @@
             "version": "13.11.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
             "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+            "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -8343,6 +8388,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8351,6 +8397,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+            "dev": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -8363,6 +8410,7 @@
             "version": "0.9.1",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
             "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "dev": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -8379,6 +8427,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8387,6 +8436,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -8395,6 +8445,7 @@
             "version": "7.3.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
             "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -8409,6 +8460,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -8420,6 +8472,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8428,6 +8481,7 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+            "dev": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -8439,6 +8493,7 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -8450,6 +8505,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -8464,6 +8520,7 @@
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
             "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+            "dev": true,
             "dependencies": {
                 "acorn": "^7.4.0",
                 "acorn-jsx": "^5.3.1",
@@ -8477,6 +8534,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
             "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -8497,6 +8555,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
             "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+            "dev": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
@@ -8508,6 +8567,7 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
             "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+            "dev": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -9142,7 +9202,8 @@
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
         },
         "node_modules/fast-safe-stringify": {
             "version": "2.0.7",
@@ -9209,6 +9270,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+            "dev": true,
             "dependencies": {
                 "flat-cache": "^3.0.4"
             },
@@ -9327,6 +9389,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
             "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+            "dev": true,
             "dependencies": {
                 "flatted": "^3.1.0",
                 "rimraf": "^3.0.2"
@@ -9338,7 +9401,8 @@
         "node_modules/flatted": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-            "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA=="
+            "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
+            "dev": true
         },
         "node_modules/fn.name": {
             "version": "1.1.0",
@@ -9575,7 +9639,8 @@
         "node_modules/functional-red-black-tree": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
@@ -9614,14 +9679,6 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/get-stdin": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-            "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/get-stream": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -9638,6 +9695,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
             "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "get-intrinsic": "^1.1.1"
@@ -9792,6 +9850,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
             "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -9819,6 +9878,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
             "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "dev": true,
             "dependencies": {
                 "has-symbols": "^1.0.2"
             },
@@ -9906,7 +9966,8 @@
         "node_modules/hosted-git-info": {
             "version": "2.8.9",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+            "dev": true
         },
         "node_modules/hpack.js": {
             "version": "2.1.6",
@@ -10171,6 +10232,7 @@
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
             "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+            "dev": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -10179,6 +10241,7 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+            "dev": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -10263,6 +10326,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
             "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+            "dev": true,
             "dependencies": {
                 "get-intrinsic": "^1.1.0",
                 "has": "^1.0.3",
@@ -10322,12 +10386,14 @@
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
         },
         "node_modules/is-bigint": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
             "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
+            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -10348,6 +10414,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
             "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2"
             },
@@ -10368,6 +10435,7 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
             "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -10391,6 +10459,7 @@
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
             "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+            "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
             },
@@ -10426,6 +10495,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
             "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -10538,6 +10608,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
             "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -10561,6 +10632,7 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
             "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -10615,6 +10687,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
             "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "has-tostringtag": "^1.0.0"
@@ -10630,6 +10703,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
             "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -10647,6 +10721,7 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
             "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+            "dev": true,
             "dependencies": {
                 "has-tostringtag": "^1.0.0"
             },
@@ -10661,6 +10736,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
             "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "dev": true,
             "dependencies": {
                 "has-symbols": "^1.0.0"
             },
@@ -10688,6 +10764,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
             "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2"
             },
@@ -14939,7 +15016,8 @@
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
         },
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
@@ -14972,6 +15050,7 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
             "integrity": "sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==",
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "array-includes": "^3.1.3",
@@ -15007,12 +15086,14 @@
             "version": "0.3.21",
             "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
             "integrity": "sha512-L0IqwlIXjilBVVYKFT37X9Ih11Um5NEl9cbJIuU/SwP/zEEAbBPOnEeeuxVMf45ydWQRDQN3Nqc96OgbH1K+Pg==",
+            "dev": true,
             "peer": true
         },
         "node_modules/language-tags": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
             "integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "language-subtag-registry": "~0.3.2"
@@ -15135,6 +15216,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
             "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+            "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "parse-json": "^2.2.0",
@@ -15149,6 +15231,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
             "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -15195,7 +15278,8 @@
         "node_modules/lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+            "dev": true
         },
         "node_modules/lodash.flattendeep": {
             "version": "4.4.0",
@@ -15205,7 +15289,8 @@
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true
         },
         "node_modules/lodash.once": {
             "version": "4.1.1",
@@ -15215,7 +15300,8 @@
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-            "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM="
+            "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+            "dev": true
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
@@ -15704,7 +15790,8 @@
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
         },
         "node_modules/negotiator": {
             "version": "0.6.3",
@@ -15778,6 +15865,7 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
             "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
             "dependencies": {
                 "hosted-git-info": "^2.1.4",
                 "resolve": "^1.10.0",
@@ -15983,6 +16071,7 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
             "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
@@ -15996,6 +16085,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
             "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
@@ -16013,6 +16103,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
             "integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "define-properties": "^1.1.3",
@@ -16038,6 +16129,7 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
             "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
@@ -16229,6 +16321,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -16240,6 +16333,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true,
             "dependencies": {
                 "error-ex": "^1.2.0"
             },
@@ -16285,6 +16379,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
             "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -16309,7 +16404,8 @@
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
         },
         "node_modules/path-to-regexp": {
             "version": "0.1.7",
@@ -16321,6 +16417,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
             "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+            "dev": true,
             "dependencies": {
                 "pify": "^2.0.0"
             },
@@ -16332,6 +16429,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
             "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -16380,6 +16478,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+            "dev": true,
             "dependencies": {
                 "find-up": "^2.1.0"
             },
@@ -16391,6 +16490,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "dev": true,
             "dependencies": {
                 "locate-path": "^2.0.0"
             },
@@ -16402,6 +16502,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
             "dependencies": {
                 "p-locate": "^2.0.0",
                 "path-exists": "^3.0.0"
@@ -16414,6 +16515,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+            "dev": true,
             "dependencies": {
                 "p-try": "^1.0.0"
             },
@@ -16425,6 +16527,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true,
             "dependencies": {
                 "p-limit": "^1.1.0"
             },
@@ -16436,6 +16539,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
             "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -16549,6 +16653,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -16570,6 +16675,7 @@
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "loose-envify": "^1.4.0",
@@ -16695,12 +16801,14 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "dev": true,
             "peer": true
         },
         "node_modules/read-pkg": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
             "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+            "dev": true,
             "dependencies": {
                 "load-json-file": "^2.0.0",
                 "normalize-package-data": "^2.3.2",
@@ -16714,6 +16822,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
             "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+            "dev": true,
             "dependencies": {
                 "find-up": "^2.0.0",
                 "read-pkg": "^2.0.0"
@@ -16726,6 +16835,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "dev": true,
             "dependencies": {
                 "locate-path": "^2.0.0"
             },
@@ -16737,6 +16847,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
             "dependencies": {
                 "p-locate": "^2.0.0",
                 "path-exists": "^3.0.0"
@@ -16749,6 +16860,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+            "dev": true,
             "dependencies": {
                 "p-try": "^1.0.0"
             },
@@ -16760,6 +16872,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true,
             "dependencies": {
                 "p-limit": "^1.1.0"
             },
@@ -16771,6 +16884,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
             "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -16847,6 +16961,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
             "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
@@ -16863,6 +16978,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
             "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             },
@@ -17015,6 +17131,7 @@
             "version": "1.22.1",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
             "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+            "dev": true,
             "dependencies": {
                 "is-core-module": "^2.9.0",
                 "path-parse": "^1.0.7",
@@ -17052,6 +17169,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -17950,6 +18068,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
             "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+            "dev": true,
             "dependencies": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
@@ -17958,12 +18077,14 @@
         "node_modules/spdx-exceptions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+            "dev": true
         },
         "node_modules/spdx-expression-parse": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "dev": true,
             "dependencies": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
@@ -17972,7 +18093,8 @@
         "node_modules/spdx-license-ids": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-            "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA=="
+            "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
+            "dev": true
         },
         "node_modules/spdy": {
             "version": "4.0.2",
@@ -18168,6 +18290,7 @@
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
             "integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
+            "dev": true,
             "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
@@ -18187,6 +18310,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
             "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3"
@@ -18199,6 +18323,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
             "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3"
@@ -18222,6 +18347,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
             "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -18247,6 +18373,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             },
@@ -18303,6 +18430,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -18314,6 +18442,7 @@
             "version": "6.7.2",
             "resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
             "integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
+            "dev": true,
             "dependencies": {
                 "ajv": "^8.0.1",
                 "lodash.clonedeep": "^4.5.0",
@@ -18330,6 +18459,7 @@
             "version": "8.6.3",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
             "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+            "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -18344,7 +18474,8 @@
         "node_modules/table/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true
         },
         "node_modules/tapable": {
             "version": "2.2.1",
@@ -18501,7 +18632,8 @@
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
         },
         "node_modules/throttleit": {
             "version": "1.0.0",
@@ -18619,6 +18751,7 @@
             "version": "3.9.0",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
             "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+            "dev": true,
             "dependencies": {
                 "@types/json5": "^0.0.29",
                 "json5": "^1.0.1",
@@ -18630,6 +18763,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
             "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+            "dev": true,
             "dependencies": {
                 "minimist": "^1.2.0"
             },
@@ -18775,6 +18909,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
             "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.1",
                 "has-bigints": "^1.0.1",
@@ -19003,7 +19138,8 @@
         "node_modules/v8-compile-cache": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-            "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
+            "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+            "dev": true
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.0.1",
@@ -19023,6 +19159,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
             "dependencies": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
@@ -19449,6 +19586,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
             "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "dev": true,
             "dependencies": {
                 "is-bigint": "^1.0.1",
                 "is-boolean-object": "^1.1.0",
@@ -19464,6 +19602,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
             "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+            "dev": true,
             "dependencies": {
                 "has-symbols": "^1.0.2"
             },
@@ -19548,6 +19687,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -19701,21 +19841,11 @@
         "packages/configs": {
             "name": "cloudify-ui-common-configs",
             "version": "0.0.1",
-            "license": "ISC",
+            "license": "Apache-2.0",
             "devDependencies": {
                 "eslint": "^7.32.0",
-                "eslint-plugin-chai-friendly": "^0.6.0",
-                "eslint-plugin-cypress": "^2.11.3",
-                "eslint-plugin-import": "^2.22.1",
-                "eslint-plugin-jest": "^24.1.0",
-                "eslint-plugin-jsdoc": "^30.6.4",
-                "eslint-plugin-node": "^11.1.0",
-                "eslint-plugin-prettier": "^3.1.4",
-                "eslint-plugin-scanjs-rules": "^0.2.1",
-                "eslint-plugin-security": "^1.4.0"
-            },
-            "peerDependencies": {
-                "eslint": "^7.32.0",
+                "eslint-config-airbnb": "^18.2.1",
+                "eslint-config-airbnb-base": "^14.2.1",
                 "eslint-plugin-chai-friendly": "^0.6.0",
                 "eslint-plugin-cypress": "^2.11.3",
                 "eslint-plugin-import": "^2.22.1",
@@ -19735,49 +19865,27 @@
                 "@cypress/code-coverage": "^3.10.0",
                 "@cypress/webpack-dev-server": "^1.6.0",
                 "cypress": "^8.2.0"
-            },
-            "devDependencies": {
-                "eslint": "^7.32.0",
-                "eslint-plugin-cypress": "^2.11.3"
             }
         },
         "packages/frontend": {
             "name": "cloudify-ui-common-frontend",
             "version": "0.0.1",
             "license": "Apache-2.0",
-            "dependencies": {
-                "eslint-config-airbnb": "^18.2.1",
-                "eslint-config-airbnb-base": "^14.2.1",
-                "eslint-config-prettier": "^6.12.0"
-            },
             "devDependencies": {
-                "@babel/core": "^7.11.6",
-                "@babel/preset-env": "^7.11.5",
-                "@babel/preset-typescript": "^7.12.7",
                 "@rollup/plugin-babel": "^5.2.2",
                 "@rollup/plugin-commonjs": "^17.1.0",
                 "@rollup/plugin-node-resolve": "^11.1.1",
-                "@types/jest": "^29.0.0",
                 "@typescript-eslint/eslint-plugin": "^4.33.0",
                 "@typescript-eslint/parser": "^4.33.0",
-                "babel-jest": "^26.5.2",
                 "browserslist": "^4.21.1",
-                "eslint": "^7.32.0",
-                "eslint-plugin-import": "^2.22.1",
-                "eslint-plugin-jest": "^24.1.0",
-                "eslint-plugin-jsdoc": "^30.6.4",
-                "eslint-plugin-prettier": "^3.1.4",
-                "jest": "^29.0.2",
-                "prettier": "^2.6.2",
                 "rollup": "^2.38.1",
-                "rollup-plugin-terser": "^7.0.2",
-                "typescript": "~4.4.4"
+                "rollup-plugin-terser": "^7.0.2"
             }
         },
         "packages/scripts": {
             "name": "cloudify-ui-common-scripts",
-            "version": "0.0.1",
-            "license": "ISC"
+            "version": "0.0.2-pre.0",
+            "license": "Apache-2.0"
         }
     },
     "dependencies": {
@@ -20811,6 +20919,7 @@
             "version": "7.17.2",
             "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.17.2.tgz",
             "integrity": "sha512-NcKtr2epxfIrNM4VOmPKO46TvDMCBhgi2CrSHaEarrz+Plk2K5r9QemmOFTGpZaoKnWoGH5MO+CzeRsih/Fcgg==",
+            "dev": true,
             "peer": true,
             "requires": {
                 "core-js-pure": "^3.20.2",
@@ -21181,6 +21290,7 @@
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
             "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+            "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.1.1",
@@ -21197,6 +21307,7 @@
                     "version": "13.11.0",
                     "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
                     "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+                    "dev": true,
                     "requires": {
                         "type-fest": "^0.20.2"
                     }
@@ -21204,7 +21315,8 @@
                 "type-fest": {
                     "version": "0.20.2",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-                    "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+                    "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+                    "dev": true
                 }
             }
         },
@@ -21212,6 +21324,7 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
             "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+            "dev": true,
             "requires": {
                 "@humanwhocodes/object-schema": "^1.2.0",
                 "debug": "^4.1.1",
@@ -21221,7 +21334,8 @@
         "@humanwhocodes/object-schema": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-            "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w=="
+            "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+            "dev": true
         },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -23174,7 +23288,8 @@
         "@types/json5": {
             "version": "0.0.29",
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-            "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+            "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+            "dev": true
         },
         "@types/lodash": {
             "version": "4.14.170",
@@ -23660,12 +23775,14 @@
         "acorn": {
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "dev": true
         },
         "acorn-jsx": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "dev": true,
             "requires": {}
         },
         "aggregate-error": {
@@ -23803,6 +23920,7 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
             "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+            "dev": true,
             "peer": true,
             "requires": {
                 "@babel/runtime": "^7.10.2",
@@ -23837,6 +23955,7 @@
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
             "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
@@ -23860,6 +23979,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
             "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+            "dev": true,
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.1"
@@ -23869,6 +23989,7 @@
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
             "integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
+            "dev": true,
             "peer": true,
             "requires": {
                 "call-bind": "^1.0.0",
@@ -23899,6 +24020,7 @@
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
             "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+            "dev": true,
             "peer": true
         },
         "astral-regex": {
@@ -23941,6 +24063,7 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
             "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
+            "dev": true,
             "peer": true
         },
         "axios": {
@@ -23955,6 +24078,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
             "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
+            "dev": true,
             "peer": true
         },
         "babel-eslint": {
@@ -24460,7 +24584,8 @@
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true
         },
         "camel-case": {
             "version": "4.1.2",
@@ -24755,6 +24880,8 @@
             "version": "file:packages/configs",
             "requires": {
                 "eslint": "^7.32.0",
+                "eslint-config-airbnb": "^18.2.1",
+                "eslint-config-airbnb-base": "^14.2.1",
                 "eslint-plugin-chai-friendly": "^0.6.0",
                 "eslint-plugin-cypress": "^2.11.3",
                 "eslint-plugin-import": "^2.22.1",
@@ -24771,38 +24898,20 @@
             "requires": {
                 "@cypress/code-coverage": "^3.10.0",
                 "@cypress/webpack-dev-server": "^1.6.0",
-                "cypress": "^8.2.0",
-                "eslint": "^7.32.0",
-                "eslint-plugin-cypress": "^2.11.3"
+                "cypress": "^8.2.0"
             }
         },
         "cloudify-ui-common-frontend": {
             "version": "file:packages/frontend",
             "requires": {
-                "@babel/core": "^7.11.6",
-                "@babel/preset-env": "^7.11.5",
-                "@babel/preset-typescript": "^7.12.7",
                 "@rollup/plugin-babel": "^5.2.2",
                 "@rollup/plugin-commonjs": "^17.1.0",
                 "@rollup/plugin-node-resolve": "^11.1.1",
-                "@types/jest": "^29.0.0",
                 "@typescript-eslint/eslint-plugin": "^4.33.0",
                 "@typescript-eslint/parser": "^4.33.0",
-                "babel-jest": "^26.5.2",
                 "browserslist": "^4.21.1",
-                "eslint": "^7.32.0",
-                "eslint-config-airbnb": "^18.2.1",
-                "eslint-config-airbnb-base": "^14.2.1",
-                "eslint-config-prettier": "^6.12.0",
-                "eslint-plugin-import": "^2.22.1",
-                "eslint-plugin-jest": "^24.1.0",
-                "eslint-plugin-jsdoc": "^30.6.4",
-                "eslint-plugin-prettier": "^3.1.4",
-                "jest": "^29.0.2",
-                "prettier": "^2.6.2",
                 "rollup": "^2.38.1",
-                "rollup-plugin-terser": "^7.0.2",
-                "typescript": "~4.4.4"
+                "rollup-plugin-terser": "^7.0.2"
             }
         },
         "cloudify-ui-common-scripts": {
@@ -24964,7 +25073,8 @@
         "confusing-browser-globals": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
-            "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA=="
+            "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
+            "dev": true
         },
         "connect-history-api-fallback": {
             "version": "2.0.0",
@@ -24975,7 +25085,8 @@
         "contains-path": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-            "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
+            "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+            "dev": true
         },
         "content-disposition": {
             "version": "0.5.4",
@@ -25046,6 +25157,7 @@
             "version": "3.21.1",
             "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.21.1.tgz",
             "integrity": "sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==",
+            "dev": true,
             "peer": true
         },
         "core-util-is": {
@@ -25288,6 +25400,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
             "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+            "dev": true,
             "peer": true
         },
         "dashdash": {
@@ -25331,7 +25444,8 @@
         "deep-is": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
         },
         "deepmerge": {
             "version": "4.2.2",
@@ -25574,6 +25688,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+            "dev": true,
             "requires": {
                 "esutils": "^2.0.2"
             }
@@ -25730,6 +25845,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
@@ -25738,6 +25854,7 @@
             "version": "1.19.1",
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
             "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "es-to-primitive": "^1.2.1",
@@ -25771,6 +25888,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
             "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dev": true,
             "requires": {
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
@@ -25802,6 +25920,7 @@
             "version": "7.32.0",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
             "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "7.12.11",
                 "@eslint/eslintrc": "^0.4.3",
@@ -25849,6 +25968,7 @@
                     "version": "7.12.11",
                     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
                     "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+                    "dev": true,
                     "requires": {
                         "@babel/highlight": "^7.10.4"
                     }
@@ -25857,6 +25977,7 @@
                     "version": "4.1.2",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
                     "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
                     "requires": {
                         "ansi-styles": "^4.1.0",
                         "supports-color": "^7.1.0"
@@ -25866,6 +25987,7 @@
                             "version": "4.3.0",
                             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
                             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                            "dev": true,
                             "requires": {
                                 "color-convert": "^2.0.1"
                             }
@@ -25874,6 +25996,7 @@
                             "version": "7.2.0",
                             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
                             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                            "dev": true,
                             "requires": {
                                 "has-flag": "^4.0.0"
                             }
@@ -25884,6 +26007,7 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
                     "requires": {
                         "color-name": "~1.1.4"
                     }
@@ -25891,12 +26015,14 @@
                 "color-name": {
                     "version": "1.1.4",
                     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
                 },
                 "cross-spawn": {
                     "version": "7.0.3",
                     "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
                     "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+                    "dev": true,
                     "requires": {
                         "path-key": "^3.1.0",
                         "shebang-command": "^2.0.0",
@@ -25906,17 +26032,20 @@
                 "escape-string-regexp": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+                    "dev": true
                 },
                 "eslint-visitor-keys": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
+                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+                    "dev": true
                 },
                 "globals": {
                     "version": "13.11.0",
                     "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
                     "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+                    "dev": true,
                     "requires": {
                         "type-fest": "^0.20.2"
                     }
@@ -25924,12 +26053,14 @@
                 "has-flag": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
                 },
                 "levn": {
                     "version": "0.4.1",
                     "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
                     "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+                    "dev": true,
                     "requires": {
                         "prelude-ls": "^1.2.1",
                         "type-check": "~0.4.0"
@@ -25939,6 +26070,7 @@
                     "version": "0.9.1",
                     "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
                     "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+                    "dev": true,
                     "requires": {
                         "deep-is": "^0.1.3",
                         "fast-levenshtein": "^2.0.6",
@@ -25951,17 +26083,20 @@
                 "path-key": {
                     "version": "3.1.1",
                     "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+                    "dev": true
                 },
                 "prelude-ls": {
                     "version": "1.2.1",
                     "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-                    "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+                    "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+                    "dev": true
                 },
                 "semver": {
                     "version": "7.3.5",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
                     "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
@@ -25970,6 +26105,7 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
                     "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "dev": true,
                     "requires": {
                         "shebang-regex": "^3.0.0"
                     }
@@ -25977,12 +26113,14 @@
                 "shebang-regex": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+                    "dev": true
                 },
                 "type-check": {
                     "version": "0.4.0",
                     "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
                     "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+                    "dev": true,
                     "requires": {
                         "prelude-ls": "^1.2.1"
                     }
@@ -25990,12 +26128,14 @@
                 "type-fest": {
                     "version": "0.20.2",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-                    "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+                    "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+                    "dev": true
                 },
                 "which": {
                     "version": "2.0.2",
                     "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
                     "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
                     "requires": {
                         "isexe": "^2.0.0"
                     }
@@ -26006,6 +26146,7 @@
             "version": "18.2.1",
             "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
             "integrity": "sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==",
+            "dev": true,
             "requires": {
                 "eslint-config-airbnb-base": "^14.2.1",
                 "object.assign": "^4.1.2",
@@ -26016,24 +26157,18 @@
             "version": "14.2.1",
             "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
             "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
+            "dev": true,
             "requires": {
                 "confusing-browser-globals": "^1.0.10",
                 "object.assign": "^4.1.2",
                 "object.entries": "^1.1.2"
             }
         },
-        "eslint-config-prettier": {
-            "version": "6.12.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.12.0.tgz",
-            "integrity": "sha512-9jWPlFlgNwRUYVoujvWTQ1aMO8o6648r+K7qU7K5Jmkbyqav1fuEZC0COYpGBxyiAJb65Ra9hrmFx19xRGwXWw==",
-            "requires": {
-                "get-stdin": "^6.0.0"
-            }
-        },
         "eslint-import-resolver-node": {
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
             "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+            "dev": true,
             "requires": {
                 "debug": "^2.6.9",
                 "resolve": "^1.13.1"
@@ -26043,6 +26178,7 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -26050,7 +26186,8 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
@@ -26058,6 +26195,7 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
             "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+            "dev": true,
             "requires": {
                 "debug": "^2.6.9",
                 "pkg-dir": "^2.0.0"
@@ -26067,6 +26205,7 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -26074,7 +26213,8 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
@@ -26107,6 +26247,7 @@
         "eslint-plugin-import": {
             "version": "2.22.1",
             "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+            "dev": true,
             "requires": {
                 "array-includes": "^3.1.1",
                 "array.prototype.flat": "^1.2.3",
@@ -26127,6 +26268,7 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -26135,6 +26277,7 @@
                     "version": "1.5.0",
                     "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
                     "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+                    "dev": true,
                     "requires": {
                         "esutils": "^2.0.2",
                         "isarray": "^1.0.0"
@@ -26143,7 +26286,8 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
@@ -26192,6 +26336,7 @@
             "version": "6.5.1",
             "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.5.1.tgz",
             "integrity": "sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==",
+            "dev": true,
             "peer": true,
             "requires": {
                 "@babel/runtime": "^7.16.3",
@@ -26212,6 +26357,7 @@
                     "version": "9.2.2",
                     "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
                     "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+                    "dev": true,
                     "peer": true
                 }
             }
@@ -26256,6 +26402,7 @@
             "version": "7.29.2",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.2.tgz",
             "integrity": "sha512-ypEBTKOy5liFQXZWMchJ3LN0JX1uPI6n7MN7OPHKacqXAxq5gYC30TdO7wqGYQyxD1OrzpobdHC3hDmlRWDg9w==",
+            "dev": true,
             "peer": true,
             "requires": {
                 "array-includes": "^3.1.4",
@@ -26278,6 +26425,7 @@
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
                     "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+                    "dev": true,
                     "peer": true,
                     "requires": {
                         "esutils": "^2.0.2"
@@ -26287,12 +26435,14 @@
                     "version": "5.3.0",
                     "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
                     "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+                    "dev": true,
                     "peer": true
                 },
                 "resolve": {
                     "version": "2.0.0-next.3",
                     "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
                     "integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
+                    "dev": true,
                     "peer": true,
                     "requires": {
                         "is-core-module": "^2.2.0",
@@ -26303,6 +26453,7 @@
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true,
                     "peer": true
                 }
             }
@@ -26311,6 +26462,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
             "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
+            "dev": true,
             "peer": true,
             "requires": {}
         },
@@ -26344,6 +26496,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
             "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+            "dev": true,
             "requires": {
                 "eslint-visitor-keys": "^1.1.0"
             }
@@ -26351,12 +26504,14 @@
         "eslint-visitor-keys": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-            "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
+            "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+            "dev": true
         },
         "espree": {
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
             "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+            "dev": true,
             "requires": {
                 "acorn": "^7.4.0",
                 "acorn-jsx": "^5.3.1",
@@ -26366,7 +26521,8 @@
                 "eslint-visitor-keys": {
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
                 }
             }
         },
@@ -26379,6 +26535,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
             "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+            "dev": true,
             "requires": {
                 "estraverse": "^5.1.0"
             },
@@ -26386,7 +26543,8 @@
                 "estraverse": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+                    "dev": true
                 }
             }
         },
@@ -26893,7 +27051,8 @@
         "fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
         },
         "fast-safe-stringify": {
             "version": "2.0.7",
@@ -26951,6 +27110,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+            "dev": true,
             "requires": {
                 "flat-cache": "^3.0.4"
             }
@@ -27050,6 +27210,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
             "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+            "dev": true,
             "requires": {
                 "flatted": "^3.1.0",
                 "rimraf": "^3.0.2"
@@ -27058,7 +27219,8 @@
         "flatted": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-            "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA=="
+            "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
+            "dev": true
         },
         "fn.name": {
             "version": "1.1.0",
@@ -27219,7 +27381,8 @@
         "functional-red-black-tree": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
         },
         "gensync": {
             "version": "1.0.0-beta.2",
@@ -27246,11 +27409,6 @@
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
             "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
         },
-        "get-stdin": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-            "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
-        },
         "get-stream": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -27264,6 +27422,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
             "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "get-intrinsic": "^1.1.1"
@@ -27382,7 +27541,8 @@
         "has-bigints": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-            "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+            "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+            "dev": true
         },
         "has-flag": {
             "version": "3.0.0",
@@ -27398,6 +27558,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
             "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "dev": true,
             "requires": {
                 "has-symbols": "^1.0.2"
             }
@@ -27459,7 +27620,8 @@
         "hosted-git-info": {
             "version": "2.8.9",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+            "dev": true
         },
         "hpack.js": {
             "version": "2.1.6",
@@ -27649,12 +27811,14 @@
         "ignore": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+            "dev": true
         },
         "import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+            "dev": true,
             "requires": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -27714,6 +27878,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
             "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+            "dev": true,
             "requires": {
                 "get-intrinsic": "^1.1.0",
                 "has": "^1.0.3",
@@ -27763,12 +27928,14 @@
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
         },
         "is-bigint": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
-            "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA=="
+            "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
+            "dev": true
         },
         "is-binary-path": {
             "version": "2.1.0",
@@ -27783,6 +27950,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
             "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2"
             }
@@ -27796,7 +27964,8 @@
         "is-callable": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-            "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+            "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+            "dev": true
         },
         "is-ci": {
             "version": "2.0.0",
@@ -27811,6 +27980,7 @@
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
             "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+            "dev": true,
             "requires": {
                 "has": "^1.0.3"
             }
@@ -27838,7 +28008,8 @@
         "is-date-object": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+            "dev": true
         },
         "is-descriptor": {
             "version": "0.1.6",
@@ -27913,7 +28084,8 @@
         "is-negative-zero": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-            "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
+            "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+            "dev": true
         },
         "is-number": {
             "version": "3.0.0",
@@ -27938,7 +28110,8 @@
         "is-number-object": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
-            "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw=="
+            "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
+            "dev": true
         },
         "is-path-inside": {
             "version": "3.0.3",
@@ -27963,6 +28136,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
             "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "has-tostringtag": "^1.0.0"
@@ -27971,7 +28145,8 @@
         "is-shared-array-buffer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-            "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
+            "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+            "dev": true
         },
         "is-stream": {
             "version": "1.1.0",
@@ -27983,6 +28158,7 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
             "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+            "dev": true,
             "requires": {
                 "has-tostringtag": "^1.0.0"
             }
@@ -27991,6 +28167,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
             "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "dev": true,
             "requires": {
                 "has-symbols": "^1.0.0"
             }
@@ -28009,6 +28186,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
             "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2"
             }
@@ -31258,7 +31436,8 @@
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
         },
         "json-stringify-safe": {
             "version": "5.0.1",
@@ -31283,6 +31462,7 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
             "integrity": "sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==",
+            "dev": true,
             "peer": true,
             "requires": {
                 "array-includes": "^3.1.3",
@@ -31309,12 +31489,14 @@
             "version": "0.3.21",
             "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
             "integrity": "sha512-L0IqwlIXjilBVVYKFT37X9Ih11Um5NEl9cbJIuU/SwP/zEEAbBPOnEeeuxVMf45ydWQRDQN3Nqc96OgbH1K+Pg==",
+            "dev": true,
             "peer": true
         },
         "language-tags": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
             "integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
+            "dev": true,
             "peer": true,
             "requires": {
                 "language-subtag-registry": "~0.3.2"
@@ -31403,6 +31585,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
             "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "parse-json": "^2.2.0",
@@ -31413,7 +31596,8 @@
                 "pify": {
                     "version": "2.3.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
                 }
             }
         },
@@ -31450,7 +31634,8 @@
         "lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+            "dev": true
         },
         "lodash.flattendeep": {
             "version": "4.4.0",
@@ -31460,7 +31645,8 @@
         "lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true
         },
         "lodash.once": {
             "version": "4.1.1",
@@ -31470,7 +31656,8 @@
         "lodash.truncate": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-            "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM="
+            "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+            "dev": true
         },
         "log-symbols": {
             "version": "4.1.0",
@@ -31850,7 +32037,8 @@
         "natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
         },
         "negotiator": {
             "version": "0.6.3",
@@ -31917,6 +32105,7 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
             "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
             "requires": {
                 "hosted-git-info": "^2.1.4",
                 "resolve": "^1.10.0",
@@ -32075,6 +32264,7 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
             "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
@@ -32085,6 +32275,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
             "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+            "dev": true,
             "peer": true,
             "requires": {
                 "call-bind": "^1.0.2",
@@ -32096,6 +32287,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
             "integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
+            "dev": true,
             "peer": true,
             "requires": {
                 "define-properties": "^1.1.3",
@@ -32115,6 +32307,7 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
             "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
@@ -32260,6 +32453,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
             "requires": {
                 "callsites": "^3.0.0"
             }
@@ -32268,6 +32462,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true,
             "requires": {
                 "error-ex": "^1.2.0"
             }
@@ -32305,7 +32500,8 @@
         "path-exists": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -32321,7 +32517,8 @@
         "path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
         },
         "path-to-regexp": {
             "version": "0.1.7",
@@ -32333,6 +32530,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
             "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+            "dev": true,
             "requires": {
                 "pify": "^2.0.0"
             },
@@ -32340,7 +32538,8 @@
                 "pify": {
                     "version": "2.3.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
                 }
             }
         },
@@ -32379,6 +32578,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+            "dev": true,
             "requires": {
                 "find-up": "^2.1.0"
             },
@@ -32387,6 +32587,7 @@
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
                     "requires": {
                         "locate-path": "^2.0.0"
                     }
@@ -32395,6 +32596,7 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
                     "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
                     "requires": {
                         "p-locate": "^2.0.0",
                         "path-exists": "^3.0.0"
@@ -32404,6 +32606,7 @@
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
                     "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
                     "requires": {
                         "p-try": "^1.0.0"
                     }
@@ -32412,6 +32615,7 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
                     "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
                     "requires": {
                         "p-limit": "^1.1.0"
                     }
@@ -32419,7 +32623,8 @@
                 "p-try": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
                 }
             }
         },
@@ -32500,7 +32705,8 @@
         "progress": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true
         },
         "prompts": {
             "version": "2.4.2",
@@ -32516,6 +32722,7 @@
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+            "dev": true,
             "peer": true,
             "requires": {
                 "loose-envify": "^1.4.0",
@@ -32617,12 +32824,14 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "dev": true,
             "peer": true
         },
         "read-pkg": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
             "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+            "dev": true,
             "requires": {
                 "load-json-file": "^2.0.0",
                 "normalize-package-data": "^2.3.2",
@@ -32633,6 +32842,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
             "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+            "dev": true,
             "requires": {
                 "find-up": "^2.0.0",
                 "read-pkg": "^2.0.0"
@@ -32642,6 +32852,7 @@
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
                     "requires": {
                         "locate-path": "^2.0.0"
                     }
@@ -32650,6 +32861,7 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
                     "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
                     "requires": {
                         "p-locate": "^2.0.0",
                         "path-exists": "^3.0.0"
@@ -32659,6 +32871,7 @@
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
                     "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
                     "requires": {
                         "p-try": "^1.0.0"
                     }
@@ -32667,6 +32880,7 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
                     "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
                     "requires": {
                         "p-limit": "^1.1.0"
                     }
@@ -32674,7 +32888,8 @@
                 "p-try": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
                 }
             }
         },
@@ -32741,6 +32956,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
             "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
+            "dev": true,
             "peer": true,
             "requires": {
                 "call-bind": "^1.0.2",
@@ -32750,7 +32966,8 @@
         "regexpp": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-            "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
+            "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+            "dev": true
         },
         "regexpu-core": {
             "version": "4.7.1",
@@ -32869,6 +33086,7 @@
             "version": "1.22.1",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
             "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+            "dev": true,
             "requires": {
                 "is-core-module": "^2.9.0",
                 "path-parse": "^1.0.7",
@@ -32895,7 +33113,8 @@
         "resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true
         },
         "resolve-url": {
             "version": "0.2.1",
@@ -33601,6 +33820,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
             "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+            "dev": true,
             "requires": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
@@ -33609,12 +33829,14 @@
         "spdx-exceptions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+            "dev": true
         },
         "spdx-expression-parse": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "dev": true,
             "requires": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
@@ -33623,7 +33845,8 @@
         "spdx-license-ids": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-            "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA=="
+            "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
+            "dev": true
         },
         "spdy": {
             "version": "4.0.2",
@@ -33781,6 +34004,7 @@
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
             "integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
+            "dev": true,
             "peer": true,
             "requires": {
                 "call-bind": "^1.0.2",
@@ -33797,6 +34021,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
             "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3"
@@ -33806,6 +34031,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
             "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3"
@@ -33822,7 +34048,8 @@
         "strip-bom": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true
         },
         "strip-eof": {
             "version": "1.0.0",
@@ -33838,7 +34065,8 @@
         "strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true
         },
         "supports-color": {
             "version": "5.5.0",
@@ -33878,12 +34106,14 @@
         "supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true
         },
         "table": {
             "version": "6.7.2",
             "resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
             "integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
+            "dev": true,
             "requires": {
                 "ajv": "^8.0.1",
                 "lodash.clonedeep": "^4.5.0",
@@ -33897,6 +34127,7 @@
                     "version": "8.6.3",
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
                     "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+                    "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -33907,7 +34138,8 @@
                 "json-schema-traverse": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+                    "dev": true
                 }
             }
         },
@@ -34013,7 +34245,8 @@
         "text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
         },
         "throttleit": {
             "version": "1.0.0",
@@ -34112,6 +34345,7 @@
             "version": "3.9.0",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
             "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+            "dev": true,
             "requires": {
                 "@types/json5": "^0.0.29",
                 "json5": "^1.0.1",
@@ -34123,6 +34357,7 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
                     "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "dev": true,
                     "requires": {
                         "minimist": "^1.2.0"
                     }
@@ -34229,6 +34464,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
             "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1",
                 "has-bigints": "^1.0.1",
@@ -34398,7 +34634,8 @@
         "v8-compile-cache": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-            "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
+            "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+            "dev": true
         },
         "v8-to-istanbul": {
             "version": "9.0.1",
@@ -34415,6 +34652,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
             "requires": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
@@ -34724,6 +34962,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
             "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "dev": true,
             "requires": {
                 "is-bigint": "^1.0.1",
                 "is-boolean-object": "^1.1.0",
@@ -34736,6 +34975,7 @@
                     "version": "1.0.4",
                     "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
                     "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+                    "dev": true,
                     "requires": {
                         "has-symbols": "^1.0.2"
                     }
@@ -34805,7 +35045,8 @@
         "word-wrap": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "dev": true
         },
         "wrap-ansi": {
             "version": "6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7828,6 +7828,21 @@
                 "eslint-plugin-import": "^2.22.1"
             }
         },
+        "node_modules/eslint-config-prettier": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+            "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+            "dev": true,
+            "dependencies": {
+                "get-stdin": "^6.0.0"
+            },
+            "bin": {
+                "eslint-config-prettier-check": "bin/cli.js"
+            },
+            "peerDependencies": {
+                "eslint": ">=3.14.1"
+            }
+        },
         "node_modules/eslint-import-resolver-node": {
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
@@ -9677,6 +9692,15 @@
             "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/get-stdin": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+            "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/get-stream": {
@@ -19846,6 +19870,7 @@
                 "eslint": "^7.32.0",
                 "eslint-config-airbnb": "^18.2.1",
                 "eslint-config-airbnb-base": "^14.2.1",
+                "eslint-config-prettier": "^6.12.0",
                 "eslint-plugin-chai-friendly": "^0.6.0",
                 "eslint-plugin-cypress": "^2.11.3",
                 "eslint-plugin-import": "^2.22.1",
@@ -19884,7 +19909,7 @@
         },
         "packages/scripts": {
             "name": "cloudify-ui-common-scripts",
-            "version": "0.0.2-pre.0",
+            "version": "0.0.1",
             "license": "Apache-2.0"
         }
     },
@@ -24882,6 +24907,7 @@
                 "eslint": "^7.32.0",
                 "eslint-config-airbnb": "^18.2.1",
                 "eslint-config-airbnb-base": "^14.2.1",
+                "eslint-config-prettier": "^6.12.0",
                 "eslint-plugin-chai-friendly": "^0.6.0",
                 "eslint-plugin-cypress": "^2.11.3",
                 "eslint-plugin-import": "^2.22.1",
@@ -26164,6 +26190,15 @@
                 "object.entries": "^1.1.2"
             }
         },
+        "eslint-config-prettier": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+            "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+            "dev": true,
+            "requires": {
+                "get-stdin": "^6.0.0"
+            }
+        },
         "eslint-import-resolver-node": {
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
@@ -27408,6 +27443,12 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
             "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
+        },
+        "get-stdin": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+            "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+            "dev": true
         },
         "get-stream": {
             "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "author": "Cloudify Platform Ltd. <cosmo-admin@cloudify.co>",
     "scripts": {
         "clean": "git clean -fXd -e \\!node_modules -e \\!node_modules/**/*",
-        "publish": "MAIN_BRANCH=RD-5955 bash packages/scripts/create-version.sh"
+        "publish": "bash packages/scripts/create-version.sh"
     },
     "dependencies": {},
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "author": "Cloudify Platform Ltd. <cosmo-admin@cloudify.co>",
     "scripts": {
         "clean": "git clean -fXd -e \\!node_modules -e \\!node_modules/**/*",
-        "publish:major": "bash ci/publish-version.sh major",
-        "publish:minor": "bash ci/publish-version.sh minor",
-        "publish:patch": "bash ci/publish-version.sh patch"
+        "publish": "MAIN_BRANCH=RD-5955 bash packages/scripts/create-version.sh"
     },
     "dependencies": {},
     "devDependencies": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -2,7 +2,7 @@
     "name": "cloudify-ui-common-backend",
     "version": "0.0.1",
     "description": "Common Cloudify UI backend library",
-    "homepage": "https://github.com/cloudify-cosmo/cloudify-ui-common/blob/master/backend/README.md",
+    "homepage": "https://github.com/cloudify-cosmo/cloudify-ui-common/blob/master/packages/backend/README.md",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/cloudify-cosmo/cloudify-ui-common.git"

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -17,6 +17,7 @@
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-airbnb-base": "^14.2.1",
+        "eslint-config-prettier": "^6.12.0",
         "eslint-plugin-chai-friendly": "^0.6.0",
         "eslint-plugin-cypress": "^2.11.3",
         "eslint-plugin-import": "^2.22.1",

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -2,7 +2,7 @@
     "name": "cloudify-ui-common-configs",
     "version": "0.0.1",
     "description": "Common Cloudify UI tools configuration library",
-    "homepage": "https://github.com/cloudify-cosmo/cloudify-ui-common/blob/master/configs/README.md",
+    "homepage": "https://github.com/cloudify-cosmo/cloudify-ui-common/blob/master/packages/configs/README.md",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/cloudify-cosmo/cloudify-ui-common.git"

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -2,7 +2,7 @@
     "name": "cloudify-ui-common-cypress",
     "version": "0.0.1",
     "description": "Common Cloudify UI Cypress library",
-    "homepage": "https://github.com/cloudify-cosmo/cloudify-ui-common/blob/master/cypress/README.md",
+    "homepage": "https://github.com/cloudify-cosmo/cloudify-ui-common/blob/master/packages/cypress/README.md",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/cloudify-cosmo/cloudify-ui-common.git"

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -2,7 +2,7 @@
     "name": "cloudify-ui-common-frontend",
     "version": "0.0.1",
     "description": "Common Cloudify UI frontend library",
-    "homepage": "https://github.com/cloudify-cosmo/cloudify-ui-common/blob/master/frontend/README.md",
+    "homepage": "https://github.com/cloudify-cosmo/cloudify-ui-common/blob/master/packages/frontend/README.md",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/cloudify-cosmo/cloudify-ui-common.git"

--- a/packages/scripts/create-version.sh
+++ b/packages/scripts/create-version.sh
@@ -87,8 +87,12 @@ log "Creating ${NPM_PACKAGE_NAME} ${NEXT_VERSION}...";
 log "Creating version publish branch...";
 if [ -n "$IS_WORKSPACE_PACKAGE" ]; then
     NEXT_VERSION_BRANCH="publish_${PACKAGE_NAME}_${NEXT_VERSION}"
+    COMMIT_MESSAGE="Bump ${PACKAGE_NAME} version to ${NEXT_VERSION}"
+    GIT_TAG="${PACKAGE_NAME}_${NEXT_VERSION}"
 else
     NEXT_VERSION_BRANCH="publish_${NEXT_VERSION}"
+    COMMIT_MESSAGE="Bump version to ${NEXT_VERSION}"
+    GIT_TAG="${NEXT_VERSION}"
 fi
 
 git checkout -b ${NEXT_VERSION_BRANCH}
@@ -96,8 +100,8 @@ git add package.json
 if [ -z "$IS_WORKSPACE_PACKAGE" ]; then
     git add package-lock.json
 fi
-git commit -m "Bump version to ${NEXT_VERSION}"
-git tag ${NEXT_VERSION}
+git commit -m "${COMMIT_MESSAGE}"
+git tag ${GIT_TAG}
 
 log "This is the last step before CI-based npm publish.";
 log "Are you sure you want to trigger publish ${NPM_PACKAGE_NAME} ${NEXT_VERSION}?";

--- a/packages/scripts/create-version.sh
+++ b/packages/scripts/create-version.sh
@@ -3,7 +3,7 @@ set -e
 
 #===================================================================================
 # Usage:
-#   createVersion <major|minor|patch>
+#   create-version.sh <version-type> [<package-name>]
 #
 # Description:
 #   Create new version of package to be published on NPM.
@@ -13,74 +13,106 @@ set -e
 #   MAIN_BRANCH - (optional) Repository main branch (default: master)
 #
 # Arguments:
-#   $1 (version type) - "patch", "minor" and "major" strings allowed
+#   $1 (version type) - `npm version` strings allowed
+#                       see https://docs.npmjs.com/cli/v8/commands/npm-version#workspaces
+#   $2 (package name) - last portion of the package name inside `packages` directory
 #
 # Returns:
 #   None
 #===================================================================================
 
-createVersion() {
-    log() {
-        LOG_PREFIX="create-version.sh:"
-        echo -e $LOG_PREFIX $@
-    }
-
-    NPM_PACKAGE_NAME=`cut -d "=" -f 2 <<< $(npm run env | grep "npm_package_name")`
-
-    MAIN_BRANCH=${MAIN_BRANCH:-master}
-    log "Switching to main branch (${MAIN_BRANCH}) and checking if its up-to-date...";
-    git checkout ${MAIN_BRANCH} || {
-      log "Error during checking out ${MAIN_BRANCH} branch"
-      false
-    }
-    git fetch || {
-      log "Error during fetching data from repository"
-      false
-    }
-    git pull || {
-      log "Error during pulling ${MAIN_BRANCH} branch"
-      false
-    }
-    git diff origin/${MAIN_BRANCH} --exit-code --compact-summary || {
-      log "Working directory not clean. Delete or push your changes to ${MAIN_BRANCH}}."
-      false
-    }
-
-    log "Running tests and build..."
-    npm run test || {
-      log "Running tests failed"
-      false
-    }
-    npm run build || {
-      log "Running build failed"
-      false
-    }
-
-    NEXT_VERSION=$(npm version --no-git-tag-version "$@")
-    log "Creating ${NPM_PACKAGE_NAME} ${NEXT_VERSION}...";
-
-    log "Creating version publish branch...";
-    NEXT_VERSION_BRANCH="publish-${NEXT_VERSION}"
-    git checkout -b ${NEXT_VERSION_BRANCH}
-    git add package.json package-lock.json
-    git commit -m "Bump version to ${NEXT_VERSION}"
-    git tag ${NEXT_VERSION}
-
-    log "This is the last step before CI-based npm publish.";
-    log "Are you sure you want to trigger ${NPM_PACKAGE_NAME} ${NEXT_VERSION} version publish?";
-    select choice in "Yes" "No"; do
-    case "$choice" in
-        Yes)
-            log "Pushing changes...";
-            git push origin ${NEXT_VERSION_BRANCH} tag ${NEXT_VERSION}
-            git checkout ${MAIN_BRANCH}
-            break;;
-        *)
-            log "Reverting changes...";
-            git checkout ${MAIN_BRANCH}
-            git tag -d ${NEXT_VERSION}
-            git branch -D ${NEXT_VERSION_BRANCH}
-            break;;
-    esac
-    done
+log() {
+    LOG_PREFIX="create-version.sh:"
+    echo -e $LOG_PREFIX $@
 }
+
+VERSION_TYPE=$1
+PACKAGE_NAME=$2
+
+if [ -n "$PACKAGE_NAME" ]; then
+    IS_WORKSPACE_PACKAGE=1
+    cd packages/$2 || {
+        log "Invalid package name provided"
+        false
+    }
+fi
+NPM_PACKAGE_NAME=`cut -d "=" -f 2 <<< $(npm run env | grep "npm_package_name")`
+
+MAIN_BRANCH=${MAIN_BRANCH:-master}
+log "Switching to main branch (${MAIN_BRANCH}) and checking if its up-to-date...";
+git checkout ${MAIN_BRANCH} || {
+  log "Error during checking out ${MAIN_BRANCH} branch"
+  false
+}
+git fetch || {
+  log "Error during fetching data from repository"
+  false
+}
+git pull || {
+  log "Error during pulling ${MAIN_BRANCH} branch"
+  false
+}
+git diff origin/${MAIN_BRANCH} --exit-code --compact-summary || {
+  log "Working directory not clean. Delete or push your changes to ${MAIN_BRANCH}}."
+  false
+}
+
+log "Running tests and build..."
+npm run lint --if-present || {
+  log "Running lint check failed"
+  false
+}
+npm run check-types --if-present || {
+  log "Running types check failed"
+  false
+}
+npm run test --if-present || {
+  log "Running tests failed"
+  false
+}
+npm run build --if-present || {
+  log "Running build failed"
+  false
+}
+
+NPM_VERSION_OPTIONS="--no-git-tag-version $VERSION_TYPE"
+if [[ $VERSION_TYPE == pre* ]]; then
+    NPM_VERSION_OPTIONS="$NPM_VERSION_OPTIONS --preid pre"
+fi
+echo NPM_VERSION_OPTIONS = $NPM_VERSION_OPTIONS
+npm version $NPM_VERSION_OPTIONS
+NEXT_VERSION=v$(node -p "require('./package.json').version")
+log "Creating ${NPM_PACKAGE_NAME} ${NEXT_VERSION}...";
+
+log "Creating version publish branch...";
+if [ -n "$IS_WORKSPACE_PACKAGE" ]; then
+    NEXT_VERSION_BRANCH="publish_${PACKAGE_NAME}_${NEXT_VERSION}"
+else
+    NEXT_VERSION_BRANCH="publish_${NEXT_VERSION}"
+fi
+
+git checkout -b ${NEXT_VERSION_BRANCH}
+git add package.json
+if [ -z "$IS_WORKSPACE_PACKAGE" ]; then
+    git add package-lock.json
+fi
+git commit -m "Bump version to ${NEXT_VERSION}"
+git tag ${NEXT_VERSION}
+
+log "This is the last step before CI-based npm publish.";
+log "Are you sure you want to trigger publish ${NPM_PACKAGE_NAME} ${NEXT_VERSION}?";
+select choice in "Yes" "No"; do
+case "$choice" in
+    Yes)
+        log "Pushing changes...";
+        git push origin ${NEXT_VERSION_BRANCH} tag ${NEXT_VERSION}
+        git checkout ${MAIN_BRANCH}
+        break;;
+    *)
+        log "Reverting changes...";
+        git checkout ${MAIN_BRANCH}
+        git tag -d ${NEXT_VERSION}
+        git branch -D ${NEXT_VERSION_BRANCH}
+        break;;
+esac
+done

--- a/packages/scripts/create-version.sh
+++ b/packages/scripts/create-version.sh
@@ -97,7 +97,9 @@ fi
 
 git checkout -b ${NEXT_VERSION_BRANCH}
 git add package.json
-if [ -z "$IS_WORKSPACE_PACKAGE" ]; then
+if [ -n "$IS_WORKSPACE_PACKAGE" ]; then
+    git add ../../package-lock.json
+else
     git add package-lock.json
 fi
 git commit -m "${COMMIT_MESSAGE}"

--- a/packages/scripts/create-version.sh
+++ b/packages/scripts/create-version.sh
@@ -66,7 +66,7 @@ git pull || {
   false
 }
 git diff origin/${MAIN_BRANCH} --exit-code --compact-summary || {
-  error "Working directory not clean. Delete or push your changes to ${MAIN_BRANCH}}."
+  error "Working directory not clean. Delete or push your changes to ${MAIN_BRANCH}."
   false
 }
 

--- a/packages/scripts/create-version.sh
+++ b/packages/scripts/create-version.sh
@@ -109,13 +109,13 @@ select choice in "Yes" "No"; do
 case "$choice" in
     Yes)
         log "Pushing changes...";
-        git push origin ${NEXT_VERSION_BRANCH} tag ${NEXT_VERSION}
+        git push origin ${NEXT_VERSION_BRANCH} tag ${GIT_TAG}
         git checkout ${MAIN_BRANCH}
         break;;
     *)
         log "Reverting changes...";
         git checkout ${MAIN_BRANCH}
-        git tag -d ${NEXT_VERSION}
+        git tag -d ${GIT_TAG}
         git branch -D ${NEXT_VERSION_BRANCH}
         break;;
 esac

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -2,7 +2,7 @@
     "name": "cloudify-ui-common-scripts",
     "version": "0.0.2-pre.0",
     "description": "Common Cloudify UI shell scripts library",
-    "homepage": "https://github.com/cloudify-cosmo/cloudify-ui-common/blob/master/scripts/README.md",
+    "homepage": "https://github.com/cloudify-cosmo/cloudify-ui-common/blob/master/packages/scripts/README.md",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/cloudify-cosmo/cloudify-ui-common.git"


### PR DESCRIPTION
## Description

Updated `create-version.sh` script and `Jenkinsfile` to allow sub-packages publishing.

Applied updated script in other repositories:
* https://github.com/cloudify-cosmo/cloudify-ui-components/pull/167
* https://github.com/cloudify-cosmo/cloudify-blueprint-topology/pull/227

As right now `cloudify-ui-common` repository will host 5 NPM packages, so release notes mechanism must be also updated. Example of a new way for providing release notes:
* [cloudify-ui-common releases / scripts_v0.0.2-pre.1](https://github.com/cloudify-cosmo/cloudify-ui-common/releases/tag/scripts_v0.0.2-pre.1)

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Successfully published few versions of `cloudify-ui-common-scripts` package - see https://www.npmjs.com/package/cloudify-ui-common-scripts.

## Documentation
Updated main `README.md` file.