### PR TITLE
RD-5955 Change NPM script name from `publish` to `publish-version` to avoid name collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ This section is divided into two parts:
 
 If you met all points from the checklist above, follow these steps:
 
-1. Provide version type and package name to `npm run publish`. For example:
+1. Provide version type and package name to `npm run publish-version`. For example:
 
-    * `npm run publish minor cypress` - to publish new minor version of `cloudify-ui-common-cypress` package
-    * `npm run publish prepatch scripts` - to publish new prerelease patch version of `cloudify-ui-common-scripts` 
+    * `npm run publish-version minor cypress` - to publish new minor version of `cloudify-ui-common-cypress` package
+    * `npm run publish-version prepatch scripts` - to publish new prerelease patch version of `cloudify-ui-common-scripts` 
       package
   
    It will create special branch, add commit to it containing version bump in `package*.json` files according to your 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "author": "Cloudify Platform Ltd. <cosmo-admin@cloudify.co>",
     "scripts": {
         "clean": "git clean -fXd -e \\!node_modules -e \\!node_modules/**/*",
-        "publish": "bash packages/scripts/create-version.sh"
+        "publish-version": "bash packages/scripts/create-version.sh"
     },
     "dependencies": {},
     "devDependencies": {


### PR DESCRIPTION
## Description

Publishing prerelease version of `cloudify-blueprint-topology` revealed an issue with name collision - on calling `npm publish` - usual NPM publish code is executed first, but then also `publish` script (if defined) from `package.json` is called. 

Ref.: https://jenkins.cloudify.co/blue/organizations/jenkins/Topology-UI-Multibranch/detail/publish_v4.1.0-pre.0/3/pipeline/


## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
`cloudify-blueprint-topology` version publish based on https://github.com/cloudify-cosmo/cloudify-blueprint-topology/pull/227 (which uses `publish-version` instead of `publish`) worked fine. See:
* https://jenkins.cloudify.co/blue/organizations/jenkins/Topology-UI-Multibranch/detail/publish_v4.1.0-pre.1/1/pipeline/
* https://www.npmjs.com/package/cloudify-blueprint-topology

## Documentation
Updated `README.md` file.
