### PR TITLE
RD-6920 Preserve backward compatibility for non-blueprint YAML generation

### DIFF
--- a/packages/backend/src/yaml.ts
+++ b/packages/backend/src/yaml.ts
@@ -41,11 +41,11 @@ function prepareIntrinsicFunctions(obj: Record<string, any>) {
 
 export const renderBlueprintYaml = (blueprint: Blueprint) => {
     prepareIntrinsicFunctions(blueprint);
-    // Omit values that are object (object or array, not a simple type) and are empty, or are just null
-    const result = omitBy(blueprint, member => member === null || (isObject(member) && isEmpty(member)));
-    return renderYaml(result);
+    return renderYaml(blueprint);
 };
 
 export const renderYaml = (source: any) => {
-    return yaml.dump(source, { lineWidth, schema });
+    // Omit values that are object (object or array, not a simple type) and are empty, or are just null
+    const result = omitBy(source, member => member === null || (isObject(member) && isEmpty(member)));
+    return yaml.dump(result, { lineWidth, schema });
 };

--- a/packages/backend/test/yaml.test.ts
+++ b/packages/backend/test/yaml.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { readFileSync } from 'fs';
-import { renderBlueprintYaml } from '../src/yaml';
+import { renderBlueprintYaml, renderYaml } from '../src/yaml';
 
 describe('yaml', () => {
     it('should convert blueprint model to YAML', () => {
@@ -19,5 +19,15 @@ describe('yaml', () => {
         };
         const expectedYaml = readFileSync(join(__dirname, 'fixtures/blueprint.yaml'), { encoding: 'utf8' });
         expect(renderBlueprintYaml(blueprintModel)).toBe(expectedYaml);
+    });
+
+    it('should not render empty or null properties on root level', () => {
+        const model = {
+            a: [],
+            b: {},
+            c: null,
+            d: ''
+        };
+        expect(renderYaml(model)).toBe("d: ''\n");
     });
 });


### PR DESCRIPTION
<!--- Provide JIRA issue ID and a general summary of your changes in the Title above -->
<!--- e.g. "RD-1234 Improve styling in SuperComponent" -->
<!--- Note that the title is used as a commit message after merging the PR -->

## Description
Preserve backward compatibility for non-blueprint YAML generation (fix for composer system tests failure)
<!--- Describe your changes to help reviewers understand the details. -->

## Screenshots / Videos
N/A
<!--- If applicable, add screenshot(s) or video(s) describing the changes you made. -->
<!--- Consider adding comparison screenshot(s) - before and after the change. -->
<!--- If not applicable, just write “N/A” in this section. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [X] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [X] I added proper labels to this PR.

## Tests
Added unit test
<!--- If applicable, describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If applicable, provide a link to system tests, e.g: -->
<!--- [#1039](https://jenkins.cloudify.co/.../1039) (2021-08-06 07:05:50) --> 
<!--- If not applicable, just write “N/A” in this section. -->

## Documentation
N/A
<!--- If applicable, describe how you documented or plan to document your changes. -->
<!--- Check UI documentation guidelines - https://cloudifysource.atlassian.net/l/c/EYWJ0XfB - for details. -->
<!--- Provide links to JIRA issues, other PRs or related documentation pages. -->
<!--- If not applicable, just write “N/A” in this section. -->
