### PR TITLE
RND-102 Filter out blobs on git clone for time optimization purpose

### DIFF
--- a/packages/backend/src/git.ts
+++ b/packages/backend/src/git.ts
@@ -6,6 +6,7 @@ import simpleGit from 'simple-git';
 
 // NOTE: The idea behind the code below has been described in more details here: https://serverfault.com/questions/544156/git-clone-fail-instead-of-prompting-for-credentials
 const disableGitAuthenticationPromptOption = '-c core.askPass=echo';
+const filterOutBlobsOption = '--filter=blob:none';
 
 const getUniqNotExistingTemporaryDirectory = (): string => {
     const repositoryPath = path.join(os.tmpdir(), uniqueDirectoryName.generate());
@@ -35,7 +36,7 @@ export const cloneGitRepo = async <Result>(
     const repositoryPath = getUniqNotExistingTemporaryDirectory();
     try {
         const gitUrl = getGitUrl(url, authHeader);
-        await simpleGit().clone(gitUrl, repositoryPath, [disableGitAuthenticationPromptOption]);
+        await simpleGit().clone(gitUrl, repositoryPath, [disableGitAuthenticationPromptOption, filterOutBlobsOption]);
         return await callback(repositoryPath);
     } catch (error: any) {
         const isAuthenticationIssue = error.message.includes('Authentication failed');

--- a/packages/backend/test/git.test.ts
+++ b/packages/backend/test/git.test.ts
@@ -22,7 +22,10 @@ describe('git', () => {
         await cloneGitRepo(url, callback, 'dXNlcjpwYXNz');
 
         const repositoryPath = 'tmp/dir';
-        expect(clone).toHaveBeenCalledWith('//user:pass@url', repositoryPath, ['-c core.askPass=echo']);
+        expect(clone).toHaveBeenCalledWith('//user:pass@url', repositoryPath, [
+            '-c core.askPass=echo',
+            '--filter=blob:none'
+        ]);
         expect(callback).toHaveBeenCalledWith(repositoryPath);
         expect(fs.rmdirSync).toHaveBeenCalledWith(repositoryPath, { recursive: true });
     });


### PR DESCRIPTION
<!--- Provide JIRA issue ID and a general summary of your changes in the Title above -->
<!--- e.g. "RD-1234 Improve styling in SuperComponent" -->
<!--- Note that the title is used as a commit message after merging the PR -->

## Description
Filter out blobs on git clone for time optimization purpose
<!--- Describe your changes to help reviewers understand the details. -->

## Screenshots / Videos
N/A
<!--- If applicable, add screenshot(s) or video(s) describing the changes you made. -->
<!--- Consider adding comparison screenshot(s) - before and after the change. -->
<!--- If not applicable, just write “N/A” in this section. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [X] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [X] I added proper labels to this PR.

## Tests
Updated unit test
<!--- If applicable, describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If applicable, provide a link to system tests, e.g: -->
<!--- [#1039](https://jenkins.cloudify.co/.../1039) (2021-08-06 07:05:50) --> 
<!--- If not applicable, just write “N/A” in this section. -->

## Documentation
N/A
<!--- If applicable, describe how you documented or plan to document your changes. -->
<!--- Check UI documentation guidelines - https://cloudifysource.atlassian.net/l/c/EYWJ0XfB - for details. -->
<!--- Provide links to JIRA issues, other PRs or related documentation pages. -->
<!--- If not applicable, just write “N/A” in this section. -->
