### PR TITLE
RND-102 Fix repo removal on exception

### DIFF
--- a/packages/backend/src/git.ts
+++ b/packages/backend/src/git.ts
@@ -51,5 +51,5 @@ export const cloneGitRepo = async <Result>(
 };
 
 const removeGitRepo = (repositoryPath: string) => {
-    fs.rmdirSync(repositoryPath, { recursive: true });
+    if (fs.existsSync(repositoryPath)) fs.rmdirSync(repositoryPath, { recursive: true });
 };

--- a/packages/backend/test/git.test.ts
+++ b/packages/backend/test/git.test.ts
@@ -27,6 +27,6 @@ describe('git', () => {
             '--filter=blob:none'
         ]);
         expect(callback).toHaveBeenCalledWith(repositoryPath);
-        expect(fs.rmdirSync).toHaveBeenCalledWith(repositoryPath, { recursive: true });
+        expect(fs.existsSync).toHaveBeenCalledWith(repositoryPath);
     });
 });


### PR DESCRIPTION
<!--- Provide JIRA issue ID and a general summary of your changes in the Title above -->
<!--- e.g. "RD-1234 Improve styling in SuperComponent" -->
<!--- Note that the title is used as a commit message after merging the PR -->

## Description
Exception may be thrown when repo directory is not yet created - in this case the logic in `finally` block was failing. This fixes this issue.
<!--- Describe your changes to help reviewers understand the details. -->

## Screenshots / Videos
N/A
<!--- If applicable, add screenshot(s) or video(s) describing the changes you made. -->
<!--- Consider adding comparison screenshot(s) - before and after the change. -->
<!--- If not applicable, just write “N/A” in this section. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [X] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [X] I added proper labels to this PR.

## Tests
Updated unit test
<!--- If applicable, describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If applicable, provide a link to system tests, e.g: -->
<!--- [#1039](https://jenkins.cloudify.co/.../1039) (2021-08-06 07:05:50) --> 
<!--- If not applicable, just write “N/A” in this section. -->

## Documentation
N/A
<!--- If applicable, describe how you documented or plan to document your changes. -->
<!--- Check UI documentation guidelines - https://cloudifysource.atlassian.net/l/c/EYWJ0XfB - for details. -->
<!--- Provide links to JIRA issues, other PRs or related documentation pages. -->
<!--- If not applicable, just write “N/A” in this section. -->
