### PR TITLE
NE-31906 Update axios to 1.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4531,9 +4531,9 @@
             }
         },
         "node_modules/@types/jest": {
-            "version": "29.0.0",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.0.0.tgz",
-            "integrity": "sha512-X6Zjz3WO4cT39Gkl0lZ2baFRaEMqJl5NC1OjElkwtNzAlbkr2K/WJXkBkH5VP0zx4Hgsd2TZYdOEfvp2Dxia+Q==",
+            "version": "29.5.12",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+            "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
             "dev": true,
             "dependencies": {
                 "expect": "^29.0.0",
@@ -5482,12 +5482,32 @@
             }
         },
         "node_modules/axios": {
-            "version": "0.26.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
-            "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
             "dependencies": {
-                "follow-redirects": "^1.14.8"
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
+        },
+        "node_modules/axios/node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/axios/node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/axobject-query": {
             "version": "2.2.0",
@@ -8823,9 +8843,9 @@
             "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
         },
         "node_modules/follow-redirects": {
-            "version": "1.14.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-            "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
             "funding": [
                 {
                     "type": "individual",
@@ -18232,7 +18252,7 @@
             "version": "1.3.3",
             "license": "Apache-2.0",
             "dependencies": {
-                "axios": "^0.26.0",
+                "axios": "^1.7.2",
                 "js-yaml": "^4.1.0",
                 "lodash": "^4.17.21",
                 "sequelize": "^6.29.0",
@@ -21699,9 +21719,9 @@
             }
         },
         "@types/jest": {
-            "version": "29.0.0",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.0.0.tgz",
-            "integrity": "sha512-X6Zjz3WO4cT39Gkl0lZ2baFRaEMqJl5NC1OjElkwtNzAlbkr2K/WJXkBkH5VP0zx4Hgsd2TZYdOEfvp2Dxia+Q==",
+            "version": "29.5.12",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+            "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
             "dev": true,
             "requires": {
                 "expect": "^29.0.0",
@@ -22432,11 +22452,30 @@
             "peer": true
         },
         "axios": {
-            "version": "0.26.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
-            "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
             "requires": {
-                "follow-redirects": "^1.14.8"
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+                    "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "proxy-from-env": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+                    "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+                }
             }
         },
         "axobject-query": {
@@ -23044,7 +23083,7 @@
                 "@types/sequelize": "^4.28.10",
                 "@types/tmp": "^0.2.1",
                 "@types/umzug": "^2.3.3",
-                "axios": "^0.26.0",
+                "axios": "^1.7.2",
                 "fs-extra": "^11.1.0",
                 "js-yaml": "^4.1.0",
                 "lodash": "^4.17.21",
@@ -25051,9 +25090,9 @@
             "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
         },
         "follow-redirects": {
-            "version": "1.14.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-            "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
         },
         "for-each": {
             "version": "0.3.3",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -28,7 +28,7 @@
         "test:only": "jest test"
     },
     "dependencies": {
-        "axios": "^0.26.0",
+        "axios": "^1.7.2",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "sequelize": "^6.29.0",


### PR DESCRIPTION
## Description
This PR updates axios to latest not vulnerable version 1.7.2

After this PR is merged I will follow with a patch release, since there are no breaking changes here and I will update it on cloudify-stage side, since we're running 1.7.2 version there already.

This should fix audit issue in cloudify-stage